### PR TITLE
feat: Add 8 popular color schemes

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -79,13 +79,21 @@ install_data(
 install_data(
     [
         'schemes/base16-twilight-dark.json',
+        'schemes/catppuccin-latte.json',
+        'schemes/catppuccin-mocha.json',
+        'schemes/dracula.json',
+        'schemes/gruvbox-dark.json',
+        'schemes/gruvbox-light.json',
         'schemes/linux.json',
         'schemes/material.json',
         'schemes/monokai.json',
+        'schemes/nord.json',
+        'schemes/one-dark.json',
         'schemes/orchis.json',
         'schemes/solarized-dark.json',
         'schemes/solarized-light.json',
         'schemes/tango.json',
+        'schemes/tokyo-night.json',
         'schemes/yaru.json',
     ],
     install_dir: pkgdatadir / 'schemes'

--- a/data/schemes/catppuccin-latte.json
+++ b/data/schemes/catppuccin-latte.json
@@ -1,0 +1,25 @@
+{
+    "name": "Catppuccin Latte",
+    "comment": "Catppuccin Latte - https://github.com/catppuccin/catppuccin",
+    "use-theme-colors": false,
+    "foreground-color": "#4C4F69",
+    "background-color": "#EFF1F5",
+    "palette": [
+        "#5C5F77",
+        "#D20F39",
+        "#40A02B",
+        "#DF8E1D",
+        "#1E66F5",
+        "#EA76CB",
+        "#179299",
+        "#ACB0BE",
+        "#6C6F85",
+        "#D20F39",
+        "#40A02B",
+        "#DF8E1D",
+        "#1E66F5",
+        "#EA76CB",
+        "#179299",
+        "#BCC0CC"
+    ]
+}

--- a/data/schemes/catppuccin-mocha.json
+++ b/data/schemes/catppuccin-mocha.json
@@ -1,0 +1,25 @@
+{
+    "name": "Catppuccin Mocha",
+    "comment": "Catppuccin Mocha - https://github.com/catppuccin/catppuccin",
+    "use-theme-colors": false,
+    "foreground-color": "#CDD6F4",
+    "background-color": "#1E1E2E",
+    "palette": [
+        "#45475A",
+        "#F38BA8",
+        "#A6E3A1",
+        "#F9E2AF",
+        "#89B4FA",
+        "#F5C2E7",
+        "#94E2D5",
+        "#BAC2DE",
+        "#585B70",
+        "#F38BA8",
+        "#A6E3A1",
+        "#F9E2AF",
+        "#89B4FA",
+        "#F5C2E7",
+        "#94E2D5",
+        "#A6ADC8"
+    ]
+}

--- a/data/schemes/dracula.json
+++ b/data/schemes/dracula.json
@@ -1,0 +1,25 @@
+{
+    "name": "Dracula",
+    "comment": "Dracula - https://draculatheme.com",
+    "use-theme-colors": false,
+    "foreground-color": "#F8F8F2",
+    "background-color": "#282A36",
+    "palette": [
+        "#21222C",
+        "#FF5555",
+        "#50FA7B",
+        "#F1FA8C",
+        "#BD93F9",
+        "#FF79C6",
+        "#8BE9FD",
+        "#F8F8F2",
+        "#6272A4",
+        "#FF6E6E",
+        "#69FF94",
+        "#FFFFA5",
+        "#D6ACFF",
+        "#FF92DF",
+        "#A4FFFF",
+        "#FFFFFF"
+    ]
+}

--- a/data/schemes/gruvbox-dark.json
+++ b/data/schemes/gruvbox-dark.json
@@ -1,0 +1,25 @@
+{
+    "name": "Gruvbox Dark",
+    "comment": "Gruvbox Dark - https://github.com/morhetz/gruvbox",
+    "use-theme-colors": false,
+    "foreground-color": "#EBDBB2",
+    "background-color": "#282828",
+    "palette": [
+        "#282828",
+        "#CC241D",
+        "#98971A",
+        "#D79921",
+        "#458588",
+        "#B16286",
+        "#689D6A",
+        "#A89984",
+        "#928374",
+        "#FB4934",
+        "#B8BB26",
+        "#FABD2F",
+        "#83A598",
+        "#D3869B",
+        "#8EC07C",
+        "#EBDBB2"
+    ]
+}

--- a/data/schemes/gruvbox-light.json
+++ b/data/schemes/gruvbox-light.json
@@ -1,0 +1,25 @@
+{
+    "name": "Gruvbox Light",
+    "comment": "Gruvbox Light - https://github.com/morhetz/gruvbox",
+    "use-theme-colors": false,
+    "foreground-color": "#3C3836",
+    "background-color": "#FBF1C7",
+    "palette": [
+        "#FBF1C7",
+        "#CC241D",
+        "#98971A",
+        "#D79921",
+        "#458588",
+        "#B16286",
+        "#689D6A",
+        "#7C6F64",
+        "#928374",
+        "#9D0006",
+        "#79740E",
+        "#B57614",
+        "#076678",
+        "#8F3F71",
+        "#427B58",
+        "#3C3836"
+    ]
+}

--- a/data/schemes/nord.json
+++ b/data/schemes/nord.json
@@ -1,0 +1,25 @@
+{
+    "name": "Nord",
+    "comment": "Nord - https://www.nordtheme.com",
+    "use-theme-colors": false,
+    "foreground-color": "#D8DEE9",
+    "background-color": "#2E3440",
+    "palette": [
+        "#3B4252",
+        "#BF616A",
+        "#A3BE8C",
+        "#EBCB8B",
+        "#81A1C1",
+        "#B48EAD",
+        "#88C0D0",
+        "#E5E9F0",
+        "#4C566A",
+        "#BF616A",
+        "#A3BE8C",
+        "#EBCB8B",
+        "#81A1C1",
+        "#B48EAD",
+        "#8FBCBB",
+        "#ECEFF4"
+    ]
+}

--- a/data/schemes/one-dark.json
+++ b/data/schemes/one-dark.json
@@ -1,0 +1,25 @@
+{
+    "name": "One Dark",
+    "comment": "One Dark (Atom) - https://github.com/atom/one-dark-syntax",
+    "use-theme-colors": false,
+    "foreground-color": "#ABB2BF",
+    "background-color": "#282C34",
+    "palette": [
+        "#1E2127",
+        "#E06C75",
+        "#98C379",
+        "#D19A66",
+        "#61AFEF",
+        "#C678DD",
+        "#56B6C2",
+        "#ABB2BF",
+        "#5C6370",
+        "#E06C75",
+        "#98C379",
+        "#D19A66",
+        "#61AFEF",
+        "#C678DD",
+        "#56B6C2",
+        "#FFFFFF"
+    ]
+}

--- a/data/schemes/tokyo-night.json
+++ b/data/schemes/tokyo-night.json
@@ -1,0 +1,25 @@
+{
+    "name": "Tokyo Night",
+    "comment": "Tokyo Night - https://github.com/folke/tokyonight.nvim",
+    "use-theme-colors": false,
+    "foreground-color": "#C0CAF5",
+    "background-color": "#1A1B26",
+    "palette": [
+        "#15161E",
+        "#F7768E",
+        "#9ECE6A",
+        "#E0AF68",
+        "#7AA2F7",
+        "#BB9AF7",
+        "#7DCFFF",
+        "#A9B1D6",
+        "#414868",
+        "#FF899D",
+        "#9FE044",
+        "#FABA4A",
+        "#8DB0FF",
+        "#C7A9FF",
+        "#A4DAFF",
+        "#C0CAF5"
+    ]
+}


### PR DESCRIPTION
## Summary

- Adds 8 widely-used color schemes: Catppuccin Latte, Catppuccin Mocha, Dracula, Gruvbox Dark, Gruvbox Light, Nord, One Dark (Atom), Tokyo Night
- Includes two light themes (Catppuccin Latte, Gruvbox Light) to complement the existing dark-heavy defaults
- Registers all new schemes in Meson build

## Test plan

- [x] Copied schemes to `~/.config/tilix/schemes/` and verified they load correctly in Tilix preferences
- [x] Visual check of all 8 themes in a running terminal
- [ ] CI validates build

Built with the help of an AI agent.