### PR TITLE
fix: Handle malformed URIs in OSC 7 and drag-and-drop

### DIFF
--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -2654,7 +2654,11 @@ private:
             return;
         }
         trace("Current directory: " ~ cwd);
-        directory = URI.filenameFromUri(cwd, hostname);
+        try {
+            directory = URI.filenameFromUri(cwd, hostname);
+        } catch (Exception e) {
+            warning("Failed to parse current directory URI '" ~ cwd ~ "': " ~ e.msg);
+        }
     }
 
     /**
@@ -3410,7 +3414,12 @@ private:
                         trace("Converted filename " ~ filename);
                     } else {
                         string hostname;
-                        filename = URI.filenameFromUri(uri, hostname);
+                        try {
+                            filename = URI.filenameFromUri(uri, hostname);
+                        } catch (Exception e) {
+                            warning("Failed to parse dropped URI '" ~ uri ~ "': " ~ e.msg);
+                            continue;
+                        }
                     }
                     string quoted = ShellUtils.shellQuote(filename) ~ " ";
                     vte.feedChild(quoted);


### PR DESCRIPTION
## Summary

- Wraps two unprotected `URI.filenameFromUri()` calls in try-catch blocks
- Prevents crash when OSC 7 contains an invalid hostname (e.g. Docker containers with numeric hostnames like `66c5115672b5`)
- Prevents crash when a malformed URI is drag-and-dropped onto the terminal
- A third call site was already protected; this aligns the other two with the same pattern

Fixes gnunn1/tilix#2244.

## Test plan

- [x] Local build passes
- [x] CI validates on all targets

Built with the help of an AI agent.