### PR TITLE
feat: Open new tabs next to the current tab

### DIFF
--- a/source/gx/tilix/appwindow.d
+++ b/source/gx/tilix/appwindow.d
@@ -773,11 +773,12 @@ private:
 
     void addSession(Session session) {
         int index;
+        int insertPos = nb.getCurrentPage() + 1;
         if (!useTabs) {
-            index = nb.appendPage(session, session.name);
+            index = nb.insertPage(session, new Label(session.name), insertPos);
         } else {
             SessionTabLabel label = new SessionTabLabel(nb.getTabPos, session.displayName, session);
-            index = nb.appendPage(session, label);
+            index = nb.insertPage(session, label, insertPos);
         }
         nb.showAll();
         nb.setCurrentPage(index);


### PR DESCRIPTION
## Summary

- New session tabs now open immediately after the currently active tab instead of at the end
- Matches the behavior of browsers and most modern tabbed applications
- Replaces `appendPage` with `insertPage` at `currentPage + 1` in `addSession`

Refs gnunn1/tilix#2136.

## Test plan

- [x] Open 3 tabs, click tab 1, open new tab → appears between tab 1 and tab 2
- [x] Click last tab, open new tab → appears at the end
- [x] With only 1 tab, open new tab → works normally
- [x] CI validates on all targets

Built with the help of an AI agent.