### PR TITLE
fix: Color schemes with use-theme-colors shown as Custom

### DIFF
--- a/source/gx/tilix/colorschemes.d
+++ b/source/gx/tilix/colorschemes.d
@@ -103,7 +103,7 @@ class ColorScheme {
 
             return false;
         }
-        if (useThemeColors) {
+        if (!useThemeColors) {
             if (!(equal(scheme.background, this.background) &&
                  equal(scheme.foreground, this.foreground))) {
                      return false;


### PR DESCRIPTION
## Summary

- Fixes color schemes with `"use-theme-colors": true` (e.g. Tango) being shown as "Custom" when reopening preferences
- The foreground/background comparison was inverted: it compared colors when `useThemeColors` was `true`, but those schemes don't define explicit fg/bg — they inherit from the GTK theme, causing a mismatch
- One-character fix: `if (useThemeColors)` → `if (!useThemeColors)`

## Test plan

- [x] Select Tango, close preferences, reopen → shows "Tango" (was "Custom")
- [x] Select Solarized Dark, close preferences, reopen → still shows "Solarized Dark"
- [x] Select Tango, uncheck "Use theme colors" → correctly becomes "Custom"
- [x] Select Solarized Dark, check "Use theme colors" → correctly becomes "Custom"
- [x] CI validates on all targets

Built with the help of an AI agent.