### PR TITLE
feat: Add ~ and @ to default word-select characters

### DIFF
--- a/data/gsettings/com.gexperts.Tilix.gschema.xml
+++ b/data/gsettings/com.gexperts.Tilix.gschema.xml
@@ -756,7 +756,7 @@
       <description>The title supports tokens which are replaced at runtime, additionally pango markup can be used as well.</description>
     </key>
     <key name="select-by-word-chars" type="s">
-      <default>'-,./?%&amp;#:_'</default>
+      <default>'-,./?%&amp;#:_~@'</default>
       <summary>Characters which are considered as part of word-wise selection</summary>
       <description>Set of characters which will be considered parts of a word when doing word-wise selection, in addition to the default which only considers alphanumeric characters part of a word.</description>
     </key>


### PR DESCRIPTION
## Summary

- Adds `~` and `@` to the default word-selection characters for new profiles
- Double-clicking now selects paths like `~/Documents` and addresses like `user@hostname` as a whole word
- Existing users can manually add these in Preferences > Profile > General > selectable symbols upon word

Refs gnunn1/tilix#2125.

## Test plan

- [x] Verified manually adding `~@` to word-select chars enables the expected behavior
- [x] Schema default value is well-formed XML
- [x] CI validates on all targets

Built with the help of an AI agent.