### PR TITLE
fix: Strip protocol prefix from proxy host to avoid duplication

### DIFF
--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -3103,6 +3103,14 @@ private:
             int port = gsProxyScheme.getInt("port");
             if (host.length == 0 || port == 0) return;
 
+            // Strip protocol prefix if already present in the host value
+            foreach (prefix; ["http://", "https://", "socks://", "ftp://"]) {
+                if (host.startsWith(prefix)) {
+                    host = host[prefix.length .. $];
+                    break;
+                }
+            }
+
             string value = urlScheme ~ "://";
             if (scheme == "http") {
                 if (gsProxyScheme.getBoolean("use-authentication")) {


### PR DESCRIPTION
## Summary

- Strips protocol prefixes (`http://`, `https://`, `socks://`, `ftp://`) from the GNOME proxy host setting before constructing the proxy URL
- Prevents duplicated schemes like `http://http://proxyhost` in environment variables

Refs gnunn1/tilix#2257.

## Test plan

- [x] Local build passes
- [x] CI validates on all targets

Built with the help of an AI agent.