### PR TITLE
fix: Prevent restarting commands from stealing focus

### DIFF
--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -2784,7 +2784,9 @@ private:
             outputError(msg, workingDir, args, envv);
             showInfoBarMessage(msg);
         }
-        vte.grabFocus();
+        if (vte.hasFocus()) {
+            vte.grabFocus();
+        }
     }
 
     enum O_CLOEXEC = 0x80000;


### PR DESCRIPTION
## Summary

- Prevents `grabFocus` from being called when a terminal's command restarts automatically
- Only grabs focus if the terminal already has it, preserving keyboard focus in other terminals
- Initial terminal spawns still focus correctly

Refs gnunn1/tilix#2182.

## Test plan

- [x] Create a profile with custom command `sleep 1` and exit action "Restart the command"
- [x] Split window, apply restart profile to one terminal, type in the other
- [x] Verified focus stays in the active terminal during restarts
- [x] CI validates on all targets

Built with the help of an AI agent.