### PR TITLE
fix: Use setText instead of setMarkup for terminal title

### DIFF
--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -1274,7 +1274,7 @@ private:
         string title = _overrideTitle.length == 0 ? gsProfile.getString(SETTINGS_PROFILE_TITLE_KEY) : _overrideTitle;
         title = getDisplayText(title);
         if (title != lastTitle) {
-            lblTitle.setMarkup(title);
+            lblTitle.setText(title);
             lastTitle = title;
         }
         // Need to always emit title since other titles could be tracking variables that terminal isn't


### PR DESCRIPTION
## Summary

- Fixes terminal title not updating when it contains `&` characters (e.g. from `sleep 10 && ls`)
- `setMarkup` tries to parse Pango XML entities and fails on unescaped `&`; `setText` treats it as plain text

Backported from gnunn1/tilix#2204.

## Test plan

- [x] Local build passes
- [x] CI validates on all targets

Built with the help of an AI agent.