### PR TITLE
feat: Visual indicator when terminal is running as root

### DIFF
--- a/data/gsettings/com.gexperts.Tilix.gschema.xml
+++ b/data/gsettings/com.gexperts.Tilix.gschema.xml
@@ -495,9 +495,14 @@
 
     <!-- Enable process monitor -->
     <key name="process-monitor" type="b">
-      <default>false</default>
+      <default>true</default>
       <summary>Whether to to enable the process monitor</summary>
       <description>If true, the process monitor will be enabled and the option to add the process name to the title will be available.</description>
+    </key>
+    <key name="root-indicator" type="b">
+      <default>true</default>
+      <summary>Show visual indicator when running as root</summary>
+      <description>If true, a red tint and "as root" label will be shown in the terminal title bar when any process is running with elevated privileges.</description>
     </key>
 
     <!-- Global settings for triggers and custom links-->

--- a/data/resources/css/tilix.base.css
+++ b/data/resources/css/tilix.base.css
@@ -134,6 +134,11 @@ revealer.right > scrolledwindow {
     80%  {-gtk-icon-transform: translateX(1px);}
 }
 
+.tilix-root-indicator {
+  color: #CC0000;
+  font-weight: bold;
+}
+
 .tilix-bell {
   background: none;
   opacity: 0;

--- a/source/gx/tilix/prefeditor/prefdialog.d
+++ b/source/gx/tilix/prefeditor/prefdialog.d
@@ -1628,6 +1628,11 @@ private:
         CheckButton cbCopyOnSelect = new CheckButton(_("Automatically copy text to clipboard when selecting"));
         bh.bind(SETTINGS_COPY_ON_SELECT_KEY, cbCopyOnSelect, "active", GSettingsBindFlags.DEFAULT);
         add(cbCopyOnSelect);
+
+        //Root Indicator
+        CheckButton cbRootIndicator = new CheckButton(_("Show visual indicator when running as root"));
+        bh.bind(SETTINGS_ROOT_INDICATOR, cbRootIndicator, "active", GSettingsBindFlags.DEFAULT);
+        add(cbRootIndicator);
     }
 
 public:

--- a/source/gx/tilix/preferences.d
+++ b/source/gx/tilix/preferences.d
@@ -150,6 +150,7 @@ immutable string[] SETTINGS_TAB_POSITION_VALUES = ["left", "right", "top", "bott
 immutable string[] SETTINGS_QUAKE_WINDOW_POSITION_VALUES = ["top", "bottom"];
 
 enum SETTINGS_PROCESS_MONITOR = "process-monitor";
+enum SETTINGS_ROOT_INDICATOR = "root-indicator";
 
 //Proxy Environment Variables
 enum SETTINGS_SET_PROXY_ENV_KEY = "set-proxy-env";

--- a/source/gx/tilix/terminal/activeprocess.d
+++ b/source/gx/tilix/terminal/activeprocess.d
@@ -36,6 +36,28 @@ class Process {
         return to!pid_t(processStat[2]);
     }
 
+    /**
+     * Returns true if the process is running as root (effective UID == 0).
+     * Reads the Uid line from /proc/[PID]/status which has the format:
+     * Uid: real effective saved filesystem
+     */
+    bool isRoot() {
+        try {
+            string data = to!string(cast(char[]) read(format("/proc/%d/status", pid)));
+            foreach (line; data.splitLines()) {
+                if (line.startsWith("Uid:")) {
+                    auto fields = line.split();
+                    if (fields.length >= 3) {
+                        return fields[2] == "0"; // effective UID
+                    }
+                }
+            }
+        } catch (FileException fe) {
+            // Process may have exited
+        }
+        return false;
+    }
+
     string[] parseStatFile() {
         try {
             string data = to!string(cast(char[])read(format("/proc/%d/stat", pid)));

--- a/source/gx/tilix/terminal/monitor.d
+++ b/source/gx/tilix/terminal/monitor.d
@@ -45,7 +45,7 @@ private:
         synchronized {
             foreach(process; processes) {
                 if (process.eventType != MonitorEventType.NONE) {
-                    onChildProcess.emit(process.eventType, process.gpid, process.activePid, process.activeName);
+                    onChildProcess.emit(process.eventType, process.gpid, process.activePid, process.activeName, process.activeIsRoot);
                     process.eventType = MonitorEventType.NONE;
                 }
             }
@@ -105,7 +105,7 @@ public:
     /**
      * When a process changes inform children
      */
-    GenericEvent!(MonitorEventType, GPid, pid_t, string) onChildProcess;
+    GenericEvent!(MonitorEventType, GPid, pid_t, string, bool) onChildProcess;
 
     static @property ProcessMonitor instance() {
         if (!tilix.processMonitor) {
@@ -130,6 +130,47 @@ enum SLEEP_CONSTANT_MS = 300;
  */
 shared ProcessStatus[GPid] processes;
 
+/**
+ * Walk up the process tree from the given PID, checking if any
+ * process has effective UID 0 (root). Stops at init (pid 1) or
+ * when the process no longer exists.
+ */
+bool checkProcessTreeForRoot(pid_t startPid) {
+    import std.conv : to;
+    import std.file : read, exists;
+    import std.format : format;
+    import std.string : splitLines, startsWith, split;
+
+    pid_t currentPid = startPid;
+    for (int depth = 0; depth < 10; depth++) {
+        if (currentPid <= 1) break;
+        auto path = format("/proc/%d/status", currentPid);
+        if (!exists(path)) break;
+        try {
+            string data = to!string(cast(char[]) read(path));
+            pid_t ppid = 0;
+            foreach (line; data.splitLines()) {
+                if (line.startsWith("Uid:")) {
+                    auto fields = line.split();
+                    if (fields.length >= 3 && fields[2] == "0") {
+                        return true;
+                    }
+                }
+                if (line.startsWith("PPid:")) {
+                    auto fields = line.split();
+                    if (fields.length >= 2) {
+                        ppid = to!pid_t(fields[1]);
+                    }
+                }
+            }
+            currentPid = ppid;
+        } catch (Exception e) {
+            break;
+        }
+    }
+    return false;
+}
+
 void monitorProcesses(int sleep, Tid tid) {
     bool abort = false;
     while (!abort) {
@@ -141,10 +182,15 @@ void monitorProcesses(int sleep, Tid tid) {
             foreach(process; processes) {
                 auto activeProcess  = activeProcesses.get(process.gpid, null);
                 // No need to raise event for same process.
-                if (activeProcess !is null && activeProcess.pid != process.activePid) {
-                    process.activeName = activeProcess.name;
-                    process.activePid = activeProcess.pid;
-                    process.eventType = MonitorEventType.STARTED;
+                if (activeProcess !is null) {
+                    // Check if active process or any of its ancestors is root
+                    bool isRoot = checkProcessTreeForRoot(activeProcess.pid);
+                    if (activeProcess.pid != process.activePid || isRoot != process.activeIsRoot) {
+                        process.activeName = activeProcess.name;
+                        process.activePid = activeProcess.pid;
+                        process.activeIsRoot = isRoot;
+                        process.eventType = MonitorEventType.STARTED;
+                    }
                 }
             }
         }
@@ -163,6 +209,7 @@ shared class ProcessStatus {
     GPid gpid;
     pid_t activePid = -1;
     string activeName = "";
+    bool activeIsRoot = false;
     MonitorEventType eventType = MonitorEventType.NONE;
 
     this(GPid gpid) {

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -226,6 +226,7 @@ private:
     Spinner spBell;
     Image imgReadOnly;
     Image imgNewOuput;
+    Label lblRootIndicator;
 
     SimpleActionGroup sagTerminalActions;
 
@@ -415,6 +416,23 @@ private:
         imgNewOuput.setNoShowAll(true);
         imgNewOuput.setTooltipText(_("New output"));
         bTitle.packEnd(imgNewOuput, false, false, 0);
+
+        //Root Indicator - apply inline CSS for the root title bar tint
+        import gtk.CssProvider;
+        import gdk.Screen;
+        import gdk.Display;
+        auto rootCss = new CssProvider();
+        rootCss.loadFromData(".tilix-root-title { background: rgba(204, 0, 0, 0.45); }");
+        StyleContext.addProviderForScreen(
+            Display.getDefault().getDefaultScreen(),
+            rootCss, ProviderPriority.APPLICATION);
+
+        //Root Indicator label
+        lblRootIndicator = new Label("");
+        lblRootIndicator.setMarkup("<span weight=\"bold\">" ~ _("as root") ~ "</span>");
+        lblRootIndicator.setTooltipText(_("Running as root"));
+        lblRootIndicator.setNoShowAll(true);
+        bTitle.packEnd(lblRootIndicator, false, false, 0);
 
         //Terminal Bell Spinner
         spBell = new Spinner();
@@ -3706,10 +3724,22 @@ private:
 
 // Process monitoring
 private:
-    void childProcessEvent(MonitorEventType eventType, GPid process, pid_t child, string name) {
+    void childProcessEvent(MonitorEventType eventType, GPid process, pid_t child, string name, bool isRoot) {
         if (process == gpid) {
             activeProcessName = name;
             updateDisplayText();
+            updateRootIndicator(isRoot);
+        }
+    }
+
+    void updateRootIndicator(bool isRoot) {
+        if (lblRootIndicator is null || bTitle is null) return;
+        if (isRoot && gsSettings.getBoolean(SETTINGS_ROOT_INDICATOR)) {
+            lblRootIndicator.show();
+            bTitle.getStyleContext().addClass("tilix-root-title");
+        } else {
+            lblRootIndicator.hide();
+            bTitle.getStyleContext().removeClass("tilix-root-title");
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds a red tint to the terminal title bar and an "as root" label when elevated privileges are detected
- Detection walks up the process tree from the active foreground process, checking `/proc/[PID]/status` for effective UID == 0
- Catches sudo, su, doas, pkexec, and any setuid binary
- Enables process monitoring by default (was opt-in)
- Adds a preference checkbox to disable the indicator

Closes #12.

## Test plan

- [x] `sudo -i` shows red tint + "as root" on that terminal only
- [x] `exit` from root removes the indicator
- [x] Multiple terminals: only the root terminal shows the indicator
- [x] Disabling the preference hides the indicator
- [x] CI validates on all targets

Built with the help of an AI agent.