### PR TITLE
feat: SSH detection and scrollback security hardening

### DIFF
--- a/data/gsettings/io.github.gwelr.ttyx.gschema.xml
+++ b/data/gsettings/io.github.gwelr.ttyx.gschema.xml
@@ -1177,11 +1177,11 @@
     </key>
     <key name="terminal-reset" type="s">
       <default>'disabled'</default>
-      <summary>Keyboard shortcut to reset the terminal states</summary>
+      <summary>Keyboard shortcut to refresh the terminal</summary>
     </key>
     <key name="terminal-reset-and-clear" type="s">
-      <default>'disabled'</default>
-      <summary>Keyboard shortcut to reset the terminal states and clear the output buffer</summary>
+      <default>'&lt;Ctrl&gt;&lt;Shift&gt;l'</default>
+      <summary>Keyboard shortcut to secure clear (reset terminal and wipe scrollback)</summary>
     </key>
     <key name="terminal-copy" type="s">
       <default>'&lt;Ctrl&gt;&lt;Shift&gt;c'</default>

--- a/data/gsettings/io.github.gwelr.ttyx.gschema.xml
+++ b/data/gsettings/io.github.gwelr.ttyx.gschema.xml
@@ -734,12 +734,7 @@
     <key name="scrollback-lines" type="i">
       <default>8192</default>
       <summary>Number of lines to keep in scrollback</summary>
-      <description>Number of scrollback lines to keep around. You can scroll back in the terminal by this number of lines; lines that don't fit in the scrollback are discarded. If scrollback_unlimited is true, this value is ignored.</description>
-    </key>
-    <key name="scrollback-unlimited" type="b">
-      <default>false</default>
-      <summary>Whether an unlimited number of lines should be kept in scrollback</summary>
-      <description>If true, scrollback lines will never be discarded. The scrollback history is stored on disk temporarily, so this may cause the system to run out of disk space if there is a lot of output to the terminal.</description>
+      <description>Number of scrollback lines to keep around. You can scroll back in the terminal by this number of lines; lines that don't fit in the scrollback are discarded. Maximum 999999. Scrollback is kept in memory only and never written to disk.</description>
     </key>
     <key name="scroll-on-keystroke" type="b">
       <default>true</default>

--- a/data/gsettings/io.github.gwelr.ttyx.gschema.xml
+++ b/data/gsettings/io.github.gwelr.ttyx.gschema.xml
@@ -515,6 +515,12 @@
       <description>If true, a blue tint and "ssh" label will be shown in the terminal title bar when a remote connection (ssh, scp, sftp, mosh) is active.</description>
     </key>
 
+    <key name="core-dump-protection" type="b">
+      <default>true</default>
+      <summary>Protect against memory dumps</summary>
+      <description>If true, the process is marked as non-dumpable to prevent core dumps and /proc/pid/mem access from leaking scrollback content. Disable this if you need to attach GDB or generate core dumps for debugging.</description>
+    </key>
+
     <!-- Global settings for triggers and custom links-->
     <key name="custom-hyperlinks" type="as">
       <default>[]</default>

--- a/data/resources/ui/shortcuts.ui
+++ b/data/resources/ui/shortcuts.ui
@@ -536,13 +536,13 @@
             <child>
               <object class="GtkShortcutsShortcut" id ="terminal-reset">
                 <property name="visible">1</property>
-                <property name="title" translatable="yes" context="shortcut window">Reset the terminal</property>
+                <property name="title" translatable="yes" context="shortcut window">Refresh terminal</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut" id ="terminal-reset-and-clear">
                 <property name="visible">1</property>
-                <property name="title" translatable="yes" context="shortcut window">Reset and clear the terminal</property>
+                <property name="title" translatable="yes" context="shortcut window">Secure Clear</property>
               </object>
             </child>
             <child>

--- a/source/gx/tilix/application.d
+++ b/source/gx/tilix/application.d
@@ -14,6 +14,8 @@ import std.process;
 import std.stdio;
 import std.variant;
 
+import core.sys.linux.sys.prctl : prctl, PR_SET_DUMPABLE;
+
 import cairo.ImageSurface;
 
 import gdk.Screen;
@@ -553,7 +555,7 @@ private:
     }
 
     void applyPreferences() {
-        foreach(key; [SETTINGS_THEME_VARIANT_KEY,SETTINGS_MENU_ACCELERATOR_KEY,SETTINGS_ACCELERATORS_ENABLED,SETTINGS_BACKGROUND_IMAGE_KEY]) {
+        foreach(key; [SETTINGS_THEME_VARIANT_KEY,SETTINGS_MENU_ACCELERATOR_KEY,SETTINGS_ACCELERATORS_ENABLED,SETTINGS_BACKGROUND_IMAGE_KEY,SETTINGS_CORE_DUMP_PROTECTION]) {
             applyPreference(key);
         }
     }
@@ -611,6 +613,12 @@ private:
                 }
                 foreach(window; appWindows) {
                     window.updateBackgroundImage();
+                }
+                break;
+            case SETTINGS_CORE_DUMP_PROTECTION:
+                size_t dumpable = gsGeneral.getBoolean(SETTINGS_CORE_DUMP_PROTECTION) ? 0 : 1;
+                if (prctl(PR_SET_DUMPABLE, dumpable, 0, 0, 0) != 0) {
+                    warning("Failed to set PR_SET_DUMPABLE");
                 }
                 break;
             default:

--- a/source/gx/tilix/prefeditor/prefdialog.d
+++ b/source/gx/tilix/prefeditor/prefdialog.d
@@ -1659,6 +1659,7 @@ public:
 class AdvancedPreferences : Box {
 private:
     GSettings gsSettings;
+    BindingHelper bh;
 
     void createUI() {
         setAllMargins(this, 18);
@@ -1669,6 +1670,23 @@ private:
 
         uint row = 0;
         createAdvancedUI(grid, row, &getSettings);
+
+        // Security section
+        Label lblSecurity = new Label(format("<b>%s</b>", _("Security")));
+        lblSecurity.setUseMarkup(true);
+        lblSecurity.setHalign(GtkAlign.START);
+        lblSecurity.setMarginTop(12);
+        grid.attach(lblSecurity, 0, row, 3, 1);
+        row++;
+
+        grid.attach(createDescriptionLabel(_("Core dump protection prevents debuggers and other processes from reading terminal memory. Disable this if you need to debug ttyx_ with GDB or generate core dumps.")), 0, row, 2, 1);
+        row++;
+
+        CheckButton cbCoreDump = new CheckButton(_("Protect against memory dumps (disable core dumps)"));
+        bh.bind(SETTINGS_CORE_DUMP_PROTECTION, cbCoreDump, "active", GSettingsBindFlags.DEFAULT);
+        cbCoreDump.setMarginTop(6);
+        grid.attach(cbCoreDump, 0, row, 2, 1);
+        row++;
 
         this.add(grid);
     }
@@ -1682,7 +1700,12 @@ public:
     this(GSettings gsSettings) {
         super(Orientation.VERTICAL, 6);
         this.gsSettings = gsSettings;
+        bh = new BindingHelper(gsSettings);
         createUI();
+        addOnDestroy(delegate(Widget) {
+            bh.unbind();
+            bh = null;
+        });
     }
 
 }

--- a/source/gx/tilix/prefeditor/profileeditor.d
+++ b/source/gx/tilix/prefeditor/profileeditor.d
@@ -1031,15 +1031,13 @@ private:
         bh.bind(SETTINGS_PROFILE_SCROLL_ON_INPUT_KEY, cbScrollOnKeystroke, "active", GSettingsBindFlags.DEFAULT);
         add(cbScrollOnKeystroke);
 
-        CheckButton cbLimitScroll = new CheckButton(_("Limit scrollback to:"));
-        bh.bind(SETTINGS_PROFILE_UNLIMITED_SCROLL_KEY, cbLimitScroll, "active", GSettingsBindFlags.DEFAULT | GSettingsBindFlags.INVERT_BOOLEAN);
-        SpinButton sbScrollbackSize = new SpinButton(256.0, to!double(int.max), 256.0);
+        Label lblScrollback = new Label(_("Scrollback lines:"));
+        lblScrollback.setHalign(GtkAlign.START);
+        SpinButton sbScrollbackSize = new SpinButton(256.0, to!double(SETTINGS_PROFILE_SCROLLBACK_LINES_MAX), 256.0);
         bh.bind(SETTINGS_PROFILE_SCROLLBACK_LINES_KEY, sbScrollbackSize, "value", GSettingsBindFlags.DEFAULT);
-        bh.bind(SETTINGS_PROFILE_UNLIMITED_SCROLL_KEY, sbScrollbackSize, "sensitive",
-                GSettingsBindFlags.GET | GSettingsBindFlags.NO_SENSITIVITY | GSettingsBindFlags.INVERT_BOOLEAN);
 
         Box b = new Box(Orientation.HORIZONTAL, 12);
-        b.add(cbLimitScroll);
+        b.add(lblScrollback);
         b.add(sbScrollbackSize);
         add(b);
     }

--- a/source/gx/tilix/preferences.d
+++ b/source/gx/tilix/preferences.d
@@ -153,6 +153,7 @@ immutable string[] SETTINGS_QUAKE_WINDOW_POSITION_VALUES = ["top", "bottom"];
 enum SETTINGS_PROCESS_MONITOR = "process-monitor";
 enum SETTINGS_ROOT_INDICATOR = "root-indicator";
 enum SETTINGS_SSH_INDICATOR = "ssh-indicator";
+enum SETTINGS_CORE_DUMP_PROTECTION = "core-dump-protection";
 
 //Proxy Environment Variables
 enum SETTINGS_SET_PROXY_ENV_KEY = "set-proxy-env";
@@ -596,4 +597,24 @@ unittest {
     // Unlimited (-1) is never allowed — clamped to minimum
     assert(clampScrollbackLines(-1) == SETTINGS_PROFILE_SCROLLBACK_LINES_MIN);
     assert(clampScrollbackLines(-1) > 0, "scrollback must always be positive to prevent VTE disk writes");
+}
+
+// -- Core dump protection --
+
+unittest {
+    // prctl PR_SET_DUMPABLE round-trip: set non-dumpable, verify, restore
+    import core.sys.linux.sys.prctl : prctl, PR_SET_DUMPABLE, PR_GET_DUMPABLE;
+
+    int original = prctl(PR_GET_DUMPABLE, 0, 0, 0, 0);
+
+    // Disable dumps
+    assert(prctl(PR_SET_DUMPABLE, 0, 0, 0, 0) == 0, "prctl SET_DUMPABLE=0 failed");
+    assert(prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) == 0, "process should be non-dumpable");
+
+    // Re-enable dumps
+    assert(prctl(PR_SET_DUMPABLE, 1, 0, 0, 0) == 0, "prctl SET_DUMPABLE=1 failed");
+    assert(prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) == 1, "process should be dumpable again");
+
+    // Restore original state
+    prctl(PR_SET_DUMPABLE, original, 0, 0, 0);
 }

--- a/source/gx/tilix/preferences.d
+++ b/source/gx/tilix/preferences.d
@@ -213,8 +213,18 @@ enum SETTINGS_PROFILE_USE_BOLD_COLOR_KEY = "bold-color-set";
 enum SETTINGS_PROFILE_SHOW_SCROLLBAR_KEY = "show-scrollbar";
 enum SETTINGS_PROFILE_SCROLL_ON_OUTPUT_KEY = "scroll-on-output";
 enum SETTINGS_PROFILE_SCROLL_ON_INPUT_KEY = "scroll-on-keystroke";
-enum SETTINGS_PROFILE_UNLIMITED_SCROLL_KEY = "scrollback-unlimited";
 enum SETTINGS_PROFILE_SCROLLBACK_LINES_KEY = "scrollback-lines";
+enum SETTINGS_PROFILE_SCROLLBACK_LINES_MAX = 999_999;
+enum SETTINGS_PROFILE_SCROLLBACK_LINES_MIN = 256;
+
+/**
+ * Clamp scrollback lines to the valid range. Prevents unlimited (-1)
+ * scrollback which causes VTE to write history to disk.
+ */
+int clampScrollbackLines(int value) {
+    import std.algorithm : clamp;
+    return clamp(value, SETTINGS_PROFILE_SCROLLBACK_LINES_MIN, SETTINGS_PROFILE_SCROLLBACK_LINES_MAX);
+}
 
 enum SETTINGS_PROFILE_BACKSPACE_BINDING_KEY = "backspace-binding";
 immutable string[] SETTINGS_PROFILE_ERASE_BINDING_VALUES = ["auto", "ascii-backspace", "ascii-delete", "delete-sequence", "tty"];
@@ -557,4 +567,33 @@ unittest {
     ProfileInfo pi1 = ProfileInfo(false, "1234", "test");
     ProfileInfo pi2 = ProfileInfo(false, "1234", "test");
     assert(pi1 == pi2);
+}
+
+// -- Scrollback limits --
+
+unittest {
+    // Normal values within range are unchanged
+    assert(clampScrollbackLines(8192) == 8192);
+    assert(clampScrollbackLines(256) == 256);
+    assert(clampScrollbackLines(999_999) == 999_999);
+    assert(clampScrollbackLines(50_000) == 50_000);
+}
+
+unittest {
+    // Values below minimum are clamped up
+    assert(clampScrollbackLines(0) == SETTINGS_PROFILE_SCROLLBACK_LINES_MIN);
+    assert(clampScrollbackLines(100) == SETTINGS_PROFILE_SCROLLBACK_LINES_MIN);
+    assert(clampScrollbackLines(255) == SETTINGS_PROFILE_SCROLLBACK_LINES_MIN);
+}
+
+unittest {
+    // Values above maximum are clamped down
+    assert(clampScrollbackLines(1_000_000) == SETTINGS_PROFILE_SCROLLBACK_LINES_MAX);
+    assert(clampScrollbackLines(int.max) == SETTINGS_PROFILE_SCROLLBACK_LINES_MAX);
+}
+
+unittest {
+    // Unlimited (-1) is never allowed — clamped to minimum
+    assert(clampScrollbackLines(-1) == SETTINGS_PROFILE_SCROLLBACK_LINES_MIN);
+    assert(clampScrollbackLines(-1) > 0, "scrollback must always be positive to prevent VTE disk writes");
 }

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -862,8 +862,8 @@ private:
 
         menuSection = new GMenu();
         menuSection.append(_("Save Output…"), getActionDetailedName(ACTION_PREFIX, ACTION_SAVE));
-        menuSection.append(_("Reset"), getActionDetailedName(ACTION_PREFIX, ACTION_RESET));
-        menuSection.append(_("Reset and Clear"), getActionDetailedName(ACTION_PREFIX, ACTION_RESET_AND_CLEAR));
+        menuSection.append(_("Refresh"), getActionDetailedName(ACTION_PREFIX, ACTION_RESET));
+        menuSection.append(_("Secure Clear"), getActionDetailedName(ACTION_PREFIX, ACTION_RESET_AND_CLEAR));
         submenu.appendSection(null, menuSection);
 
         menuSection = new GMenu();
@@ -1786,6 +1786,10 @@ private:
 
             mmContext.appendItem(clipItem);
         }
+        GMenu clearSection = new GMenu();
+        clearSection.append(_("Secure Clear"), getActionDetailedName(ACTION_PREFIX, ACTION_RESET_AND_CLEAR));
+        mmContext.appendSection(null, clearSection);
+
         //Check if titlebar is hidden and add extra items
         if (!bTitle.isVisible()) {
             GMenu windowSection = new GMenu();

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -2149,9 +2149,8 @@ private:
             vte.setScrollOnKeystroke(gsProfile.getBoolean(SETTINGS_PROFILE_SCROLL_ON_INPUT_KEY));
         });
 
-        prefRegistry.register([SETTINGS_PROFILE_UNLIMITED_SCROLL_KEY, SETTINGS_PROFILE_SCROLLBACK_LINES_KEY], {
-            auto scrollLines = gsProfile.getBoolean(SETTINGS_PROFILE_UNLIMITED_SCROLL_KEY) ? -1 : gsProfile.getInt(SETTINGS_PROFILE_SCROLLBACK_LINES_KEY);
-            vte.setScrollbackLines(scrollLines);
+        prefRegistry.register([SETTINGS_PROFILE_SCROLLBACK_LINES_KEY], {
+            vte.setScrollbackLines(clampScrollbackLines(gsProfile.getInt(SETTINGS_PROFILE_SCROLLBACK_LINES_KEY)));
         });
 
         prefRegistry.register([SETTINGS_PROFILE_BACKSPACE_BINDING_KEY], {


### PR DESCRIPTION
## Summary

- **SSH session detection (#22):** detect SSH-family processes (ssh, scp, sftp, mosh, sshfs) and display a visual indicator in the terminal title bar with blue tint, taking precedence over the root indicator
- **In-memory-only scrollback (#23):** remove unlimited scrollback option and clamp lines to 256–999,999, ensuring VTE never writes history to disk
- **Secure Clear action (#23):** rename "Reset and Clear" to "Secure Clear" with `Ctrl+Shift+L` keybinding, added to right-click context menu
- **Core dump protection (#23):** call `prctl(PR_SET_DUMPABLE, 0)` at startup to prevent memory dumps from leaking scrollback content, with a toggle in Advanced preferences for debugging

## Test plan

- [x] Unit tests for SSH process name matching and ProcessInfo struct
- [x] Unit tests for scrollback clamping (normal, min, max, unlimited blocking)
- [x] Unit test for prctl PR_SET_DUMPABLE round-trip (set/get/restore)
- [x] Manual: verify SSH indicator appears when running `ssh` in a terminal
- [x] Manual: verify Secure Clear (`Ctrl+Shift+L`) wipes scrollback
- [x] Manual: verify core dump protection via `kill -ABRT` (no core file when enabled)
- [x] Manual: verify toggling core dump protection in Advanced preferences works at runtime
- [x] Manual: verify GDB attaches cleanly when protection is disabled

Closes #22
Relates to #23