### PR TITLE
security: Harden config migration against symlink attacks

### DIFF
--- a/.github/ci/Dockerfile-debian-testing
+++ b/.github/ci/Dockerfile-debian-testing
@@ -10,8 +10,9 @@ RUN mkdir -p /build/ci/
 COPY install-deps-deb.sh /build/ci/
 RUN chmod +x /build/ci/install-deps-deb.sh && /build/ci/install-deps-deb.sh
 
-# install GtkD directly from the source repos, we don't need to build it again
-RUN eatmydata apt-get install -yq libgtkd-3-dev libvted-3-dev
+# GtkD is no longer packaged in Debian Testing, build it from source
+COPY make-install-deps-extern.sh /build/ci/
+RUN chmod +x /build/ci/make-install-deps-extern.sh && /build/ci/make-install-deps-extern.sh
 
 # finish
 WORKDIR /build

--- a/README.md
+++ b/README.md
@@ -76,12 +76,31 @@ ttyx_ is written in [D](https://dlang.org/) using GTK 3 and the GtkD bindings.
 
 ### With Meson (recommended)
 
+The Meson build resolves the GtkD bindings (`gtkd-3`, `vted-3`) via
+pkg-config, so they must be installed separately. On distros that still
+package them, apt covers everything. On Debian Testing/Sid they have
+been dropped from the archive and must be built from source.
+
 ```bash
-# Install dependencies (Debian/Ubuntu)
+# Install dependencies (Debian Stable / Ubuntu)
+sudo apt-get install libgtk-3-dev libvte-2.91-dev libatk1.0-dev \
+  libcairo2-dev libpango1.0-dev librsvg2-dev libglib2.0-dev \
+  libsecret-1-dev libgtksourceview-3.0-dev libpeas-dev dh-dlang \
+  libgtkd-3-dev libvted-3-dev
+```
+
+```bash
+# Install dependencies (Debian Testing / Sid — libgtkd-3-dev and
+# libvted-3-dev are no longer in the archive)
 sudo apt-get install libgtk-3-dev libvte-2.91-dev libatk1.0-dev \
   libcairo2-dev libpango1.0-dev librsvg2-dev libglib2.0-dev \
   libsecret-1-dev libgtksourceview-3.0-dev libpeas-dev dh-dlang
 
+# Then build and install GtkD v3.x from source — the same steps CI uses
+# are in .github/ci/make-install-deps-extern.sh
+```
+
+```bash
 # Build
 meson setup builddir --buildtype=release
 ninja -C builddir

--- a/source/gx/tilix/application.d
+++ b/source/gx/tilix/application.d
@@ -560,26 +560,49 @@ private:
     /**
      * Migrate config directory from ~/.config/tilix/ to ~/.config/ttyx/
      * on first run after switching from Tilix. Copies (does not move)
-     * the directory so the original remains as a backup.
+     * so the original remains as a backup.
+     *
+     * Symlinks are skipped (logged as warning) to prevent link-following
+     * attacks. Destination entries that already exist are also skipped
+     * to prevent writing through pre-existing symlinks or overwriting
+     * data. See #49 for the attack vectors this guards against.
      */
     void migrateConfigFromTilix() {
         string oldConfig = buildPath(Util.getUserConfigDir(), "tilix");
         string newConfig = buildPath(Util.getUserConfigDir(), APPLICATION_CONFIG_FOLDER);
-        if (exists(oldConfig) && !exists(newConfig)) {
-            try {
-                mkdirRecurse(newConfig);
-                foreach (entry; dirEntries(oldConfig, SpanMode.breadth)) {
-                    string target = buildPath(newConfig, entry.name[oldConfig.length + 1 .. $]);
-                    if (entry.isDir) {
-                        mkdirRecurse(target);
-                    } else {
-                        copy(entry.name, target);
-                    }
-                }
-                info("Migrated config from " ~ oldConfig ~ " to " ~ newConfig);
-            } catch (Exception e) {
-                warning("Config migration failed: " ~ e.msg);
+
+        if (!exists(oldConfig)) return;
+
+        // If oldConfig is itself a symlink, refuse — don't follow it.
+        try {
+            if (getLinkAttributes(oldConfig).attrIsSymlink) {
+                warning("Config migration skipped: " ~ oldConfig ~ " is a symlink");
+                return;
             }
+        } catch (Exception e) {
+            warning("Config migration skipped: could not stat " ~ oldConfig);
+            return;
+        }
+
+        // Refuse if anything exists at newConfig — including a dangling
+        // symlink, which plain exists() would report as absent.
+        bool newConfigPresent;
+        try {
+            getLinkAttributes(newConfig);
+            newConfigPresent = true;
+        } catch (Exception) {
+            newConfigPresent = false;
+        }
+        if (newConfigPresent) return;
+
+        try {
+            // mkdir (not mkdirRecurse) errors if path exists, including
+            // as a symlink — provides some TOCTOU resistance.
+            mkdir(newConfig);
+            migrateTreeRecursive(oldConfig, newConfig);
+            info("Migrated config from " ~ oldConfig ~ " to " ~ newConfig);
+        } catch (Exception e) {
+            warning("Config migration failed: " ~ e.msg);
         }
     }
 
@@ -972,4 +995,139 @@ public:
     * this instead
     */
     GenericEvent!() onThemeChange;
+}
+
+/**
+ * Walk src recursively, mirroring regular files and directories into
+ * dst. Symlinks are skipped with a warning. Paths that already exist
+ * at dst are skipped. Uses getLinkAttributes and SpanMode.shallow with
+ * followSymlink=false so the walker never follows a symlink.
+ *
+ * Free function (not a class method) so it can be unit-tested against
+ * temp directories without constructing a full Tilix application.
+ */
+package void migrateTreeRecursive(string src, string dst) {
+    import std.file : DirEntry, SpanMode, dirEntries, getLinkAttributes,
+                      attrIsSymlink, mkdir, copy;
+    import std.path : buildPath, baseName;
+
+    foreach (DirEntry entry; dirEntries(src, SpanMode.shallow, false)) {
+        string name = baseName(entry.name);
+        string target = buildPath(dst, name);
+
+        if (entry.isSymlink) {
+            warning("Skipping symlink during migration: " ~ entry.name);
+            continue;
+        }
+
+        // Check target doesn't already exist (including as a symlink).
+        // getLinkAttributes catches dangling symlinks that plain exists()
+        // would miss.
+        try {
+            getLinkAttributes(target);
+            warning("Skipping existing target during migration: " ~ target);
+            continue;
+        } catch (Exception) {
+            // target doesn't exist, good, proceed
+        }
+
+        if (entry.isDir) {
+            mkdir(target);
+            migrateTreeRecursive(entry.name, target);
+        } else if (entry.isFile) {
+            copy(entry.name, target);
+        }
+        // else: socket, pipe, device, etc. — skip silently.
+    }
+}
+
+// -- Unit tests for migrateTreeRecursive --
+
+version (unittest) {
+    import std.file : mkdir, mkdirRecurse, rmdirRecurse, write,
+                      symlink, exists, readText, tempDir;
+    import std.path : buildPath;
+    import std.uuid : randomUUID;
+}
+
+/// Source symlinks are skipped, regular files are copied.
+unittest {
+    string tmpRoot = buildPath(tempDir(), "ttyx-migration-test-" ~ randomUUID.toString);
+    scope(exit) {
+        if (exists(tmpRoot)) rmdirRecurse(tmpRoot);
+    }
+    string src = buildPath(tmpRoot, "src");
+    string dst = buildPath(tmpRoot, "dst");
+
+    mkdirRecurse(src);
+    write(buildPath(src, "safe.txt"), "ok");
+    symlink("/etc/passwd", buildPath(src, "evil"));
+    mkdir(dst);
+
+    migrateTreeRecursive(src, dst);
+
+    assert(exists(buildPath(dst, "safe.txt")));
+    assert(!exists(buildPath(dst, "evil")), "symlink should have been skipped");
+}
+
+/// Existing files at the destination are preserved, not overwritten.
+unittest {
+    string tmpRoot = buildPath(tempDir(), "ttyx-migration-test-" ~ randomUUID.toString);
+    scope(exit) {
+        if (exists(tmpRoot)) rmdirRecurse(tmpRoot);
+    }
+    string src = buildPath(tmpRoot, "src");
+    string dst = buildPath(tmpRoot, "dst");
+
+    mkdirRecurse(src);
+    write(buildPath(src, "file.txt"), "from_source");
+    mkdir(dst);
+    write(buildPath(dst, "file.txt"), "preexisting");
+
+    migrateTreeRecursive(src, dst);
+
+    assert(readText(buildPath(dst, "file.txt")) == "preexisting");
+}
+
+/// Nested directories are mirrored correctly.
+unittest {
+    string tmpRoot = buildPath(tempDir(), "ttyx-migration-test-" ~ randomUUID.toString);
+    scope(exit) {
+        if (exists(tmpRoot)) rmdirRecurse(tmpRoot);
+    }
+    string src = buildPath(tmpRoot, "src");
+    string dst = buildPath(tmpRoot, "dst");
+
+    mkdirRecurse(buildPath(src, "a", "b"));
+    write(buildPath(src, "a", "b", "deep.txt"), "deep_content");
+    mkdir(dst);
+
+    migrateTreeRecursive(src, dst);
+
+    assert(exists(buildPath(dst, "a", "b", "deep.txt")));
+    assert(readText(buildPath(dst, "a", "b", "deep.txt")) == "deep_content");
+}
+
+/// Symlinked directories in source are skipped entirely (not traversed).
+unittest {
+    string tmpRoot = buildPath(tempDir(), "ttyx-migration-test-" ~ randomUUID.toString);
+    scope(exit) {
+        if (exists(tmpRoot)) rmdirRecurse(tmpRoot);
+    }
+    string src = buildPath(tmpRoot, "src");
+    string dst = buildPath(tmpRoot, "dst");
+    string outside = buildPath(tmpRoot, "outside");
+
+    mkdirRecurse(src);
+    mkdirRecurse(outside);
+    write(buildPath(outside, "secret.txt"), "exfiltrated");
+    symlink(outside, buildPath(src, "link-to-outside"));
+    mkdir(dst);
+
+    migrateTreeRecursive(src, dst);
+
+    // The symlink should not have been followed, so the outside file
+    // should not appear in dst.
+    assert(!exists(buildPath(dst, "link-to-outside")));
+    assert(!exists(buildPath(dst, "link-to-outside", "secret.txt")));
 }

--- a/source/gx/tilix/application.d
+++ b/source/gx/tilix/application.d
@@ -559,51 +559,13 @@ private:
 
     /**
      * Migrate config directory from ~/.config/tilix/ to ~/.config/ttyx/
-     * on first run after switching from Tilix. Copies (does not move)
-     * so the original remains as a backup.
-     *
-     * Symlinks are skipped (logged as warning) to prevent link-following
-     * attacks. Destination entries that already exist are also skipped
-     * to prevent writing through pre-existing symlinks or overwriting
-     * data. See #49 for the attack vectors this guards against.
+     * on first run after switching from Tilix. Delegates to the
+     * testable free function migrateConfigBetween.
      */
     void migrateConfigFromTilix() {
         string oldConfig = buildPath(Util.getUserConfigDir(), "tilix");
         string newConfig = buildPath(Util.getUserConfigDir(), APPLICATION_CONFIG_FOLDER);
-
-        if (!exists(oldConfig)) return;
-
-        // If oldConfig is itself a symlink, refuse — don't follow it.
-        try {
-            if (getLinkAttributes(oldConfig).attrIsSymlink) {
-                warning("Config migration skipped: " ~ oldConfig ~ " is a symlink");
-                return;
-            }
-        } catch (Exception e) {
-            warning("Config migration skipped: could not stat " ~ oldConfig);
-            return;
-        }
-
-        // Refuse if anything exists at newConfig — including a dangling
-        // symlink, which plain exists() would report as absent.
-        bool newConfigPresent;
-        try {
-            getLinkAttributes(newConfig);
-            newConfigPresent = true;
-        } catch (Exception) {
-            newConfigPresent = false;
-        }
-        if (newConfigPresent) return;
-
-        try {
-            // mkdir (not mkdirRecurse) errors if path exists, including
-            // as a symlink — provides some TOCTOU resistance.
-            mkdir(newConfig);
-            migrateTreeRecursive(oldConfig, newConfig);
-            info("Migrated config from " ~ oldConfig ~ " to " ~ newConfig);
-        } catch (Exception e) {
-            warning("Config migration failed: " ~ e.msg);
-        }
+        migrateConfigBetween(oldConfig, newConfig);
     }
 
     void applyPreferences() {
@@ -998,6 +960,54 @@ public:
 }
 
 /**
+ * Core migration logic, parameterized for testability.
+ *
+ * Copies oldConfig into newConfig only if:
+ *   - oldConfig exists and is not a symlink (don't follow a symlink root)
+ *   - newConfig does not exist (including not as a dangling symlink)
+ *
+ * Returns true if the migration ran to completion, false otherwise.
+ * See #49 for the attack vectors this guards against.
+ */
+package bool migrateConfigBetween(string oldConfig, string newConfig) {
+    import std.file : exists, getLinkAttributes, attrIsSymlink, mkdir;
+
+    if (!exists(oldConfig)) return false;
+
+    // If oldConfig is itself a symlink, refuse — don't follow it.
+    try {
+        if (getLinkAttributes(oldConfig).attrIsSymlink) {
+            warning("Config migration skipped: " ~ oldConfig ~ " is a symlink");
+            return false;
+        }
+    } catch (Exception e) {
+        warning("Config migration skipped: could not stat " ~ oldConfig);
+        return false;
+    }
+
+    // Refuse if anything exists at newConfig — including a dangling
+    // symlink, which plain exists() would report as absent.
+    try {
+        getLinkAttributes(newConfig);
+        return false; // already migrated or something is there
+    } catch (Exception) {
+        // newConfig doesn't exist, proceed
+    }
+
+    try {
+        // mkdir (not mkdirRecurse) errors if path exists, including
+        // as a symlink — provides some TOCTOU resistance.
+        mkdir(newConfig);
+        migrateTreeRecursive(oldConfig, newConfig);
+        info("Migrated config from " ~ oldConfig ~ " to " ~ newConfig);
+        return true;
+    } catch (Exception e) {
+        warning("Config migration failed: " ~ e.msg);
+        return false;
+    }
+}
+
+/**
  * Walk src recursively, mirroring regular files and directories into
  * dst. Symlinks are skipped with a warning. Paths that already exist
  * at dst are skipped. Uses getLinkAttributes and SpanMode.shallow with
@@ -1130,4 +1140,93 @@ unittest {
     // should not appear in dst.
     assert(!exists(buildPath(dst, "link-to-outside")));
     assert(!exists(buildPath(dst, "link-to-outside", "secret.txt")));
+}
+
+// -- Unit tests for migrateConfigBetween --
+
+/// Normal case: src has content, dst doesn't exist, migration runs.
+unittest {
+    string tmpRoot = buildPath(tempDir(), "ttyx-migration-test-" ~ randomUUID.toString);
+    scope(exit) {
+        if (exists(tmpRoot)) rmdirRecurse(tmpRoot);
+    }
+    string src = buildPath(tmpRoot, "tilix");
+    string dst = buildPath(tmpRoot, "ttyx");
+
+    mkdirRecurse(src);
+    write(buildPath(src, "config.json"), "{}");
+
+    assert(migrateConfigBetween(src, dst));
+    assert(exists(buildPath(dst, "config.json")));
+}
+
+/// Refuses if source root is itself a symlink (attack: symlink ~/.config/tilix to /etc).
+unittest {
+    string tmpRoot = buildPath(tempDir(), "ttyx-migration-test-" ~ randomUUID.toString);
+    scope(exit) {
+        if (exists(tmpRoot)) rmdirRecurse(tmpRoot);
+    }
+    string realDir = buildPath(tmpRoot, "real");
+    string srcLink = buildPath(tmpRoot, "tilix");
+    string dst = buildPath(tmpRoot, "ttyx");
+
+    mkdirRecurse(realDir);
+    write(buildPath(realDir, "sensitive.txt"), "secret");
+    symlink(realDir, srcLink);
+
+    assert(!migrateConfigBetween(srcLink, dst));
+    assert(!exists(dst), "dst should not have been created when src is a symlink");
+}
+
+/// Refuses if dest is a dangling symlink (attack: symlink ~/.config/ttyx to attacker-writable path).
+unittest {
+    string tmpRoot = buildPath(tempDir(), "ttyx-migration-test-" ~ randomUUID.toString);
+    scope(exit) {
+        if (exists(tmpRoot)) rmdirRecurse(tmpRoot);
+    }
+    string src = buildPath(tmpRoot, "tilix");
+    string dst = buildPath(tmpRoot, "ttyx");
+    string target = buildPath(tmpRoot, "nonexistent");
+
+    mkdirRecurse(src);
+    write(buildPath(src, "a.txt"), "payload");
+    // Create dangling symlink at dst pointing to a path that doesn't exist.
+    symlink(target, dst);
+
+    assert(!migrateConfigBetween(src, dst));
+    assert(!exists(target), "dangling symlink should not have been written through");
+}
+
+/// Refuses if destination already exists as a regular directory.
+unittest {
+    string tmpRoot = buildPath(tempDir(), "ttyx-migration-test-" ~ randomUUID.toString);
+    scope(exit) {
+        if (exists(tmpRoot)) rmdirRecurse(tmpRoot);
+    }
+    string src = buildPath(tmpRoot, "tilix");
+    string dst = buildPath(tmpRoot, "ttyx");
+
+    mkdirRecurse(src);
+    write(buildPath(src, "a.txt"), "new");
+    mkdirRecurse(dst);
+    write(buildPath(dst, "existing.txt"), "keep");
+
+    assert(!migrateConfigBetween(src, dst));
+    // Existing content is preserved; nothing from src was copied.
+    assert(exists(buildPath(dst, "existing.txt")));
+    assert(!exists(buildPath(dst, "a.txt")));
+}
+
+/// Returns false when source doesn't exist (no migration needed).
+unittest {
+    string tmpRoot = buildPath(tempDir(), "ttyx-migration-test-" ~ randomUUID.toString);
+    scope(exit) {
+        if (exists(tmpRoot)) rmdirRecurse(tmpRoot);
+    }
+    string src = buildPath(tmpRoot, "tilix");
+    string dst = buildPath(tmpRoot, "ttyx");
+
+    // src is never created.
+    assert(!migrateConfigBetween(src, dst));
+    assert(!exists(dst));
 }


### PR DESCRIPTION
## Summary

Harden the Tilix→ttyx config migration (`migrateConfigFromTilix()` in `application.d`) against symlink-based attacks.

The migration added in 1.1.1 walked `~/.config/tilix/` with `SpanMode.breadth` and called `std.file.copy` with no symlink checks, enabling:
1. **Source-side symlink following** — a symlink in `~/.config/tilix/` could cause us to read arbitrary paths
2. **Dangling destination symlink** — if `~/.config/ttyx/` was a dangling symlink, `exists()` would return false and we'd write through it
3. **TOCTOU** between the `!exists()` check and `mkdirRecurse()`

## Fix

- Refuse if `~/.config/tilix/` is itself a symlink
- Use `getLinkAttributes` (lstat) to detect any entry at the target, including dangling symlinks
- Walk with `SpanMode.shallow` + `followSymlink=false`, recurse manually
- Skip symlinks encountered during traversal with a warning log
- Use `mkdir` (not `mkdirRecurse`) so creation fails on pre-existing paths
- Per-entry lstat of destination before copy/mkdir
- Extract tree walker as free function `migrateTreeRecursive` for testability

## Test plan

- [x] 4 new unit tests covering: source symlinks skipped, existing targets preserved, nested directories mirrored, symlinked directories not traversed
- [x] All tests pass (`meson test -C builddir`)
- [x] Test log confirms the skip paths are exercised (warnings emitted for symlinks and existing targets)

Closes #49