### PR TITLE
security: Fix proxy URL construction and harden log handling (#51)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -92,6 +92,7 @@ tilix_sources = [
     'source/gx/tilix/sidebar.d',
     'source/gx/util/array.d',
     'source/gx/util/path.d',
+    'source/gx/util/redact.d',
     'source/gx/util/string.d',
     'source/secret/Collection.d',
     'source/secret/Item.d',

--- a/source/app.d
+++ b/source/app.d
@@ -26,9 +26,58 @@ import gx.tilix.application;
 import gx.tilix.cmdparams;
 import gx.tilix.constants;
 
+/**
+ * Resolve the file path for the debug log (only used when USE_FILE_LOGGING is on).
+ *
+ * Prefers `$XDG_RUNTIME_DIR/ttyx.log` (typically /run/user/$UID, mode 0700
+ * and owned by the user) so the log is unreadable by other local users.
+ * Falls back to `$HOME/.cache/ttyx/ttyx.log` (also created mode 0700),
+ * and only then to `/tmp/ttyx.log` as a last resort when neither is
+ * available.
+ */
+private string resolveLogPath() {
+    import std.path : buildPath;
+    import std.file : mkdirRecurse, exists, isDir, setAttributes;
+    import core.sys.posix.sys.stat : S_IRWXU;
+
+    // Tighten permissions to 0700 on every call, not just on creation —
+    // another tool may have created `~/.cache/ttyx` with looser perms.
+    string tryDir(string dir, bool enforcePerms) {
+        if (dir.length == 0) return null;
+        try {
+            if (!exists(dir)) {
+                mkdirRecurse(dir);
+            } else if (!isDir(dir)) {
+                return null;
+            }
+            if (enforcePerms) setAttributes(dir, S_IRWXU);
+            return buildPath(dir, "ttyx.log");
+        } catch (Exception) {
+            return null;
+        }
+    }
+
+    // $XDG_RUNTIME_DIR is already 0700 by systemd convention — don't
+    // touch its mode (it may host sockets we shouldn't clobber).
+    string runtime = environment.get("XDG_RUNTIME_DIR");
+    if (auto p = tryDir(runtime, /* enforcePerms */ false)) return p;
+
+    string home = environment.get("HOME");
+    if (home.length > 0) {
+        if (auto p = tryDir(buildPath(home, ".cache", "ttyx"), true)) return p;
+    }
+
+    // Last-resort fallback — world-readable directory. USE_FILE_LOGGING
+    // defaults off, so this only matters for developer/debug builds where
+    // neither XDG_RUNTIME_DIR nor HOME is resolvable.
+    return "/tmp/ttyx.log";
+}
+
 int main(string[] args) {
     static if (USE_FILE_LOGGING) {
-        sharedLog = new shared FileLogger("/tmp/ttyx.log");
+        // FileLogger's constructors aren't `shared`, so build an unshared
+        // instance and cast — sharedLog is __gshared in current Phobos.
+        sharedLog = cast(shared) new FileLogger(resolveLogPath());
     }
 
     bool newProcess = false;

--- a/source/gx/tilix/terminal/flatpak.d
+++ b/source/gx/tilix/terminal/flatpak.d
@@ -20,6 +20,8 @@ import glib.VariantType : GVariantType = VariantType;
 import gtkc.giotypes : GDBusConnection, GDBusCallFlags, GDBusConnectionFlags, GDBusSignalCallback, GDBusSignalFlags;
 import gtkc.glibtypes;
 
+import gx.util.redact : redactSensitive;
+
 /// Delegate type for receiving host command exit notifications.
 package alias HostCommandExitedCallback = void delegate(int);
 
@@ -54,7 +56,7 @@ GVariant buildHostCommandVariant(string workingDir, string[] args, string[] envv
         if (eqPos < 1) continue;
         string key = env[0 .. eqPos];
         string val = env[eqPos + 1 .. $];
-        tracef("Adding env var %s=%s", key, val);
+        tracef("Adding env var %s=%s", key, redactSensitive(key, val));
         auto entry = new GVariant(g_variant_new("{ss}",
             toStringz(key), toStringz(val)), true);
         envBuilder.addValue(entry);

--- a/source/gx/tilix/terminal/spawn.d
+++ b/source/gx/tilix/terminal/spawn.d
@@ -12,6 +12,7 @@ import std.experimental.logger;
 import std.format : format;
 import std.process : environment;
 import std.string : split, startsWith;
+import std.uri : encodeComponent;
 
 import gio.Settings : GSettings = Settings;
 
@@ -53,6 +54,49 @@ string getHostShell() {
 }
 
 /**
+ * Build an RFC-3986-conformant proxy URL.
+ *
+ * Emits `scheme://host:port/` with optional `user[:pw]@` userinfo segment.
+ * `user` and `pw` are percent-encoded so passwords containing reserved
+ * characters (`@`, `:`, `/`, spaces, etc.) do not break the URL.
+ *
+ * Extracted as a package-level pure helper so the output is unit-testable.
+ */
+package string buildProxyUrl(string urlScheme, string user, string pw, string host, int port) {
+    string value = urlScheme ~ "://";
+    if (user.length > 0) {
+        value ~= encodeComponent(user);
+        if (pw.length > 0) {
+            value ~= ":" ~ encodeComponent(pw);
+        }
+        value ~= "@";
+    }
+    value ~= format("%s:%d/", host, port);
+    return value;
+}
+
+unittest {
+    assert(buildProxyUrl("http", "", "", "proxy.local", 8080) == "http://proxy.local:8080/");
+}
+
+unittest {
+    assert(buildProxyUrl("http", "alice", "", "proxy.local", 8080) == "http://alice@proxy.local:8080/");
+    assert(buildProxyUrl("http", "alice", "secret", "proxy.local", 8080) == "http://alice:secret@proxy.local:8080/");
+}
+
+unittest {
+    // A password containing reserved userinfo characters must survive intact.
+    auto url = buildProxyUrl("http", "user@corp", "p@ss:w/rd", "proxy.local", 3128);
+    assert(url == "http://user%40corp:p%40ss%3Aw%2Frd@proxy.local:3128/");
+}
+
+unittest {
+    // socks schemes use the same construction.
+    assert(buildProxyUrl("socks", "", "", "s.example", 1080) == "socks://s.example:1080/");
+    assert(buildProxyUrl("socks", "u", "p", "s.example", 1080) == "socks://u:p@s.example:1080/");
+}
+
+/**
  * Set proxy environment variables from GNOME's proxy settings.
  *
  * Reads the system proxy configuration (http, https, ftp, socks) from
@@ -67,6 +111,19 @@ string getHostShell() {
  *   envv = Environment variable array to append proxy vars to.
  */
 void setProxyEnv(GSettings gsSettings, GSettings gsProxy, ref string[] envv) {
+
+    // GNOME only exposes use-authentication / authentication-user / -password
+    // under the http subschema. Those same credentials apply to the HTTPS
+    // proxy as well (common deployment pattern: same upstream for both).
+    string httpAuthUser;
+    string httpAuthPw;
+    if (gsProxy !is null) {
+        GSettings httpAuth = gsProxy.getChild("http");
+        if (httpAuth.getBoolean("use-authentication")) {
+            httpAuthUser = httpAuth.getString("authentication-user");
+            httpAuthPw = httpAuth.getString("authentication-password");
+        }
+    }
 
     void addProxy(GSettings proxy, string scheme, string urlScheme, string varName) {
         GSettings gsProxyScheme = proxy.getChild(scheme);
@@ -83,23 +140,14 @@ void setProxyEnv(GSettings gsSettings, GSettings gsProxy, ref string[] envv) {
             }
         }
 
-        string value = urlScheme ~ "://";
-        if (scheme == "http") {
-            if (gsProxyScheme.getBoolean("use-authentication")) {
-                string user = gsProxyScheme.getString("authentication-user");
-                string pw = gsProxyScheme.getString("authentication-password");
-                if (user.length > 0) {
-                    value = value ~ "@" ~ user;
-                    if (pw.length > 0) {
-                        value = value ~ ":" ~ pw;
-                    }
-                    value = value ~ "@";
-                }
-            }
+        string user;
+        string pw;
+        if (scheme == "http" || scheme == "https") {
+            user = httpAuthUser;
+            pw = httpAuthPw;
         }
 
-        value = value ~ format("%s:%d/", host, port);
-        envv ~= format("%s=%s", varName, value);
+        envv ~= format("%s=%s", varName, buildProxyUrl(urlScheme, user, pw, host, port));
     }
 
     if (!gsSettings.getBoolean(SETTINGS_SET_PROXY_ENV_KEY)) return;

--- a/source/gx/util/redact.d
+++ b/source/gx/util/redact.d
@@ -1,0 +1,110 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+ * distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+module gx.util.redact;
+
+import std.regex : regex, replaceAll;
+import std.string : indexOf, toLower;
+
+enum string REDACTED = "[redacted]";
+
+private immutable string[] SENSITIVE_KEY_FRAGMENTS = [
+    "password", "passwd", "token", "secret", "api_key", "apikey",
+    "auth", "credential",
+];
+
+private immutable string[] PROXY_KEY_FRAGMENTS = [
+    "proxy",
+];
+
+/**
+ * Redact sensitive portions of an environment variable value for logging.
+ *
+ * - Keys containing a password/token/secret/auth fragment have the whole
+ *   value replaced with a placeholder.
+ * - Keys containing "proxy" have the userinfo segment of any URL-shaped
+ *   value stripped, keeping `scheme://host[:port]/...` so the log remains
+ *   useful for debugging connectivity.
+ * - Other keys pass through unchanged.
+ *
+ * Matching is case-insensitive and fragment-based: both `HTTP_PROXY` and
+ * `http_proxy`, both `API_TOKEN` and `apikey`, are recognized.
+ */
+string redactSensitive(string key, string value) {
+    if (value.length == 0) return value;
+
+    string lowerKey = key.toLower;
+
+    foreach (fragment; SENSITIVE_KEY_FRAGMENTS) {
+        if (lowerKey.indexOf(fragment) >= 0) return REDACTED;
+    }
+
+    foreach (fragment; PROXY_KEY_FRAGMENTS) {
+        if (lowerKey.indexOf(fragment) >= 0) return stripUrlUserinfo(value);
+    }
+
+    return value;
+}
+
+/**
+ * Remove the userinfo segment (user:password@) from a URL-shaped string.
+ * If the input is not URL-shaped or contains no userinfo, it is returned
+ * verbatim.
+ */
+string stripUrlUserinfo(string url) {
+    // scheme://userinfo@rest  -->  scheme://rest
+    static auto re = regex(r"^([a-zA-Z][a-zA-Z0-9+.-]*://)[^/@]+@");
+    return url.replaceAll(re, "$1");
+}
+
+// -- tests --------------------------------------------------------------
+
+unittest {
+    assert(redactSensitive("PATH", "/usr/bin:/bin") == "/usr/bin:/bin");
+    assert(redactSensitive("HOME", "/home/user") == "/home/user");
+    assert(redactSensitive("SHELL", "/bin/bash") == "/bin/bash");
+}
+
+unittest {
+    assert(redactSensitive("PASSWORD", "hunter2") == REDACTED);
+    assert(redactSensitive("MY_PASSWD", "x") == REDACTED);
+    assert(redactSensitive("API_TOKEN", "abcd") == REDACTED);
+    assert(redactSensitive("github_token", "ghp_...") == REDACTED);
+    assert(redactSensitive("CLIENT_SECRET", "shh") == REDACTED);
+    assert(redactSensitive("API_KEY", "k") == REDACTED);
+    assert(redactSensitive("BASIC_AUTH", "dXNlcjpwdw==") == REDACTED);
+}
+
+unittest {
+    // Empty value: no-op even for sensitive keys.
+    assert(redactSensitive("PASSWORD", "") == "");
+}
+
+unittest {
+    // Proxy URL with credentials: userinfo is stripped, host/port retained.
+    assert(redactSensitive("http_proxy", "http://user:pw@proxy.local:8080/")
+        == "http://proxy.local:8080/");
+    assert(redactSensitive("HTTPS_PROXY", "https://alice:secret@proxy.corp:3128/")
+        == "https://proxy.corp:3128/");
+    assert(redactSensitive("all_proxy", "socks://u:p@s.example:1080/")
+        == "socks://s.example:1080/");
+}
+
+unittest {
+    // Proxy URL without credentials is preserved as-is.
+    assert(redactSensitive("http_proxy", "http://proxy.local:8080/")
+        == "http://proxy.local:8080/");
+    // no_proxy is a comma list, not a URL — must not be mangled.
+    assert(redactSensitive("no_proxy", "localhost,127.0.0.1,.corp")
+        == "localhost,127.0.0.1,.corp");
+}
+
+unittest {
+    // Non-URL value with a proxy-shaped key is returned untouched by the
+    // strip (no regex match), so the fragment policy degrades safely.
+    assert(stripUrlUserinfo("not-a-url") == "not-a-url");
+    assert(stripUrlUserinfo("") == "");
+    assert(stripUrlUserinfo("http://host/path") == "http://host/path");
+}


### PR DESCRIPTION
Closes #51.

## Summary

Three MEDIUM-severity issues in the proxy/spawn path:

1. **Malformed proxy URL** (`spawn.d`) — output was
   `http://@user:pw@host:port/` with a stray leading `@`. Strict RFC-3986
   parsers (curl, urllib, reqwest) reject it; loose parsers misattribute
   the host. Result: proxy authentication silently failed, letting
   clients fall back to direct connections and bypass egress controls.
   Credentials were also not URL-encoded, so a password containing `@`,
   `:`, `/`, or a space mangled the URL.

2. **Plaintext password in trace log** (`flatpak.d`) — the `Adding env
   var %s=%s` trace wrote `http_proxy=http://user:password@host/` to
   the debug log when `USE_FILE_LOGGING` is enabled.

3. **Log file in world-traversable `/tmp`** (`app.d`) — `/tmp/ttyx.log`
   is readable by other local users on typical `1777` setups.

## Changes

### 1. `buildProxyUrl` helper (pure, unit-tested)

Extracted into `source/gx/tilix/terminal/spawn.d`. Emits
`scheme://[user[:pw]@]host:port/` with `std.uri.encodeComponent` applied
to both `user` and `pw`. Called from the existing `setProxyEnv` flow.

### 2. `gx.util.redact.redactSensitive(key, value)`

New module. Keys containing `password`/`token`/`secret`/`auth` fragments
get fully redacted; keys containing `proxy` get the userinfo segment
stripped while keeping `scheme://host:port/` intact for debugging.
Wired into `flatpak.d:57` — the only known env-trace call site. Module
is available for future log sites.

### 3. Log location

`app.d` now resolves the log path to:
1. `$XDG_RUNTIME_DIR/ttyx.log` (typically `/run/user/$UID`, mode 0700)
2. `$HOME/.cache/ttyx/ttyx.log` (directory tightened to 0700 even if it
   already existed)
3. `/tmp/ttyx.log` as documented last resort

`XDG_RUNTIME_DIR` permissions are intentionally not modified (systemd
convention, hosts sockets).

## Behavior change — please review

`https_proxy` previously carried **no** authentication because the auth
block was gated on `scheme == "http"`. GNOME only exposes
`use-authentication` / `authentication-user` / `-password` under the
http subschema, so the gate silently excluded HTTPS. This PR applies
the http-subschema credentials to `https_proxy` as well — matching the
common deployment where the same upstream handles both. Users who have
an HTTPS-only proxy that isn't actually authenticated will now see
creds sent that weren't before; any such user should clear
`use-authentication` on the http subschema.

## Testing

**Unit tests**:
- `buildProxyUrl`: no creds, user-only, user+pw, special characters
  (`@`, `:`, `/` in userinfo), socks scheme
- `redactSensitive`: passthrough, password/token/secret/auth full
  redaction, proxy URL userinfo stripping, non-URL values under proxy
  keys, empty values

**Manual verification** (against the built binary with
`USE_FILE_LOGGING` temporarily flipped on):

- [x] `http_proxy` = `http://user%40corp:p%40ss%3Aw%2Frd@proxy.test:8080/`
      (percent-encoding, no leading `@`, RFC-3986 conformant)
- [x] `https_proxy` carries credentials (behavior change verified)
- [x] Log file lands at `$XDG_RUNTIME_DIR/ttyx.log`, not `/tmp/ttyx.log`
- [x] Flatpak env-trace redaction covered by unit tests (site not
      exercised on native builds — expected)

## Incidental fix

`app.d`'s `new shared FileLogger(...)` didn't compile on current Phobos
(FileLogger constructors aren't `shared`). Since the toggle was needed
to verify the log-path change, included a one-line cast fix in the
log-location commit.

## References

- CWE-20 (Improper Input Validation)
- CWE-532 (Insertion of Sensitive Information into Log File)
- OWASP A02:2021, A09:2021

## Test plan

- [x] `meson test -C builddir` passes
- [x] Manual: `$http_proxy` and `$https_proxy` formatted correctly
- [x] Manual: log lands at safe location
- [x] Manual: `/tmp/ttyx.log` not created

Assisted by Claude Code.