### PR TITLE
refactor: Extract pointInTriangle to gx.util.geometry

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -91,6 +91,7 @@ tilix_sources = [
     'source/gx/tilix/shortcuts.d',
     'source/gx/tilix/sidebar.d',
     'source/gx/util/array.d',
+    'source/gx/util/geometry.d',
     'source/gx/util/path.d',
     'source/gx/util/redact.d',
     'source/gx/util/string.d',

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -129,6 +129,7 @@ import gx.gtk.util;
 import gx.gtk.vte;
 import gx.i18n.l10n;
 import gx.util.array;
+import gx.util.geometry : Point, pointInTriangle;
 import gx.util.redact : stripUrlUserinfo;
 
 import gx.tilix.application;
@@ -2835,33 +2836,12 @@ private:
      * the drag snap too.
      */
     DragQuadrant getDragQuadrant(int x, int y, Widget widget) {
-
-        /**
-         * Cribbed from Stackoverflow (http://stackoverflow.com/questions/2049582/how-to-determine-a-point-in-a-2d-triangle)
-         * since implementing my own version of barycentric method will turn my brain to mush
-         */
-        bool pointInTriangle(GdkPoint p, GdkPoint p0, GdkPoint p1, GdkPoint p2) {
-            int s = p0.y * p2.x - p0.x * p2.y + (p2.y - p0.y) * p.x + (p0.x - p2.x) * p.y;
-            int t = p0.x * p1.y - p0.y * p1.x + (p0.y - p1.y) * p.x + (p1.x - p0.x) * p.y;
-
-            if ((s < 0) != (t < 0))
-                return false;
-
-            int a = -p1.y * p2.x + p0.y * (p2.x - p1.x) + p0.x * (p1.y - p2.y) + p1.x * p2.y;
-            if (a < 0.0) {
-                s = -s;
-                t = -t;
-                a = -a;
-            }
-            return s > 0 && t > 0 && (s + t) <= a;
-        }
-
-        GdkPoint cursor = GdkPoint(x, y);
-        GdkPoint topLeft = GdkPoint(0, 0);
-        GdkPoint topRight = GdkPoint(widget.getAllocatedWidth(), 0);
-        GdkPoint bottomRight = GdkPoint(widget.getAllocatedWidth(), widget.getAllocatedHeight());
-        GdkPoint bottomLeft = GdkPoint(0, widget.getAllocatedHeight());
-        GdkPoint center = GdkPoint(widget.getAllocatedWidth() / 2, widget.getAllocatedHeight() / 2);
+        Point cursor = Point(x, y);
+        Point topLeft = Point(0, 0);
+        Point topRight = Point(widget.getAllocatedWidth(), 0);
+        Point bottomRight = Point(widget.getAllocatedWidth(), widget.getAllocatedHeight());
+        Point bottomLeft = Point(0, widget.getAllocatedHeight());
+        Point center = Point(widget.getAllocatedWidth() / 2, widget.getAllocatedHeight() / 2);
 
         //LEFT
         if (pointInTriangle(cursor, topLeft, bottomLeft, center))

--- a/source/gx/util/geometry.d
+++ b/source/gx/util/geometry.d
@@ -1,0 +1,107 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+ * distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+module gx.util.geometry;
+
+struct Point {
+    int x;
+    int y;
+}
+
+/**
+ * Barycentric test — returns true if `p` lies inside the triangle
+ * p0-p1-p2 (inclusive of edges). Works regardless of vertex winding
+ * order. Degenerate (collinear) triangles return false for every
+ * point.
+ *
+ * Cribbed from https://stackoverflow.com/questions/2049582 to avoid
+ * reimplementing barycentric math from scratch.
+ */
+bool pointInTriangle(Point p, Point p0, Point p1, Point p2) {
+    int s = p0.y * p2.x - p0.x * p2.y + (p2.y - p0.y) * p.x + (p0.x - p2.x) * p.y;
+    int t = p0.x * p1.y - p0.y * p1.x + (p0.y - p1.y) * p.x + (p1.x - p0.x) * p.y;
+
+    if ((s < 0) != (t < 0))
+        return false;
+
+    int a = -p1.y * p2.x + p0.y * (p2.x - p1.x) + p0.x * (p1.y - p2.y) + p1.x * p2.y;
+    if (a < 0) {
+        s = -s;
+        t = -t;
+        a = -a;
+    }
+    return s > 0 && t > 0 && (s + t) <= a;
+}
+
+// -- tests --------------------------------------------------------------
+
+unittest {
+    // Clearly inside: centroid of an axis-aligned right triangle.
+    auto a = Point(0, 0), b = Point(10, 0), c = Point(0, 10);
+    assert(pointInTriangle(Point(2, 2), a, b, c));
+}
+
+unittest {
+    // Clearly outside in each direction.
+    auto a = Point(0, 0), b = Point(10, 0), c = Point(0, 10);
+    assert(!pointInTriangle(Point(-1, 5), a, b, c));
+    assert(!pointInTriangle(Point(5, -1), a, b, c));
+    assert(!pointInTriangle(Point(20, 20), a, b, c));
+    assert(!pointInTriangle(Point(6, 6), a, b, c)); // outside the hypotenuse
+}
+
+unittest {
+    // Reversed winding order — the `a < 0` branch must flip signs so
+    // the result is identical regardless of vertex ordering.
+    auto a = Point(0, 0), b = Point(10, 0), c = Point(0, 10);
+    assert(pointInTriangle(Point(2, 2), a, b, c));
+    assert(pointInTriangle(Point(2, 2), c, b, a));
+    assert(pointInTriangle(Point(2, 2), b, a, c));
+}
+
+unittest {
+    // Degenerate triangle (collinear vertices): no point is inside.
+    auto a = Point(0, 0), b = Point(5, 5), c = Point(10, 10);
+    assert(!pointInTriangle(Point(5, 5), a, b, c));
+    assert(!pointInTriangle(Point(1, 1), a, b, c));
+    assert(!pointInTriangle(Point(0, 0), a, b, c));
+}
+
+unittest {
+    // Point on an edge of an axis-aligned triangle is considered
+    // inside by the current implementation (`(s + t) <= a`). Locking
+    // this in so a future refactor can't accidentally flip it.
+    auto a = Point(0, 0), b = Point(10, 0), c = Point(0, 10);
+    assert(pointInTriangle(Point(5, 5), a, b, c)); // on hypotenuse
+    // Strictly at a vertex: s or t becomes zero, so the `s > 0 && t > 0`
+    // guard rejects it. Documented behavior.
+    assert(!pointInTriangle(Point(0, 0), a, b, c));
+    assert(!pointInTriangle(Point(10, 0), a, b, c));
+    assert(!pointInTriangle(Point(0, 10), a, b, c));
+}
+
+unittest {
+    // Four-quadrant split of a 100×100 widget — the actual use case.
+    // A centered cursor lands in exactly one quadrant (the first one
+    // tested wins by short-circuit). Off-center points fall in the
+    // expected quadrant.
+    auto topLeft     = Point(0, 0);
+    auto topRight    = Point(100, 0);
+    auto bottomRight = Point(100, 100);
+    auto bottomLeft  = Point(0, 100);
+    auto center      = Point(50, 50);
+
+    // Clearly-left cursor: inside (topLeft, bottomLeft, center), not others.
+    auto leftCursor = Point(10, 50);
+    assert(pointInTriangle(leftCursor, topLeft, bottomLeft, center));
+    assert(!pointInTriangle(leftCursor, topLeft, topRight, center));
+    assert(!pointInTriangle(leftCursor, topRight, bottomRight, center));
+    assert(!pointInTriangle(leftCursor, bottomLeft, bottomRight, center));
+
+    // Clearly-top cursor.
+    auto topCursor = Point(50, 10);
+    assert(!pointInTriangle(topCursor, topLeft, bottomLeft, center));
+    assert(pointInTriangle(topCursor, topLeft, topRight, center));
+}


### PR DESCRIPTION
Pure-math lift out of the terminal widget, per our offline discussion on reducing `terminal.d` complexity.

## What and why

`pointInTriangle` was a 15-line nested function inside `getDragQuadrant` in the 178KB terminal widget file. It's pure barycentric `int` arithmetic that doesn't need to live next to VTE. Moving it to `gx.util.geometry` gets the math out of the terminal class and makes it independently testable.

## Module shape

`source/gx/util/geometry.d` defines a module-local `struct Point { int x, y; }` so the util module has no GTK/GDK dependency. Callers convert their `GdkPoint` values to `Point` at the call site — both are POD with identical layout, so this is zero-cost.

## Caller change

`getDragQuadrant` in `terminal.d`:

- removes the nested function definition (19 lines, including the Stack Overflow attribution)
- swaps six `GdkPoint` locals to `Point`
- adds `import gx.util.geometry : Point, pointInTriangle;`

Algorithm byte-identical. Drag-snapping behavior unchanged.

## Tests

New unit tests in `geometry.d` cover:
- Inside / outside cases (axis-aligned right triangle)
- Reversed vertex winding order (the `a < 0` sign-flip branch must still work)
- Degenerate (collinear) triangles return false
- Boundary behavior locked in: edge inclusive, vertex exclusive
- The four-quadrant split that is the actual use case

## Test plan

- [x] `meson test -C builddir` passes (27 modules passed unittests, was 26 before)
- [ ] Manual: not required — algorithm byte-identical, helper covered by unit tests

Assisted by Claude Code.