### PR TITLE
refactor: Extract parsePairs and process introspection to gx.util

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -92,6 +92,7 @@ tilix_sources = [
     'source/gx/tilix/sidebar.d',
     'source/gx/util/array.d',
     'source/gx/util/path.d',
+    'source/gx/util/proc.d',
     'source/gx/util/redact.d',
     'source/gx/util/string.d',
     'source/secret/Collection.d',

--- a/source/gx/tilix/terminal/activeprocess.d
+++ b/source/gx/tilix/terminal/activeprocess.d
@@ -258,3 +258,10 @@ unittest {
     assert(!info.isValid());
     assert(info.pid == -1);
 }
+
+unittest {
+    // Process.isRoot delegates to gx.util.proc.readProcStatus; verify
+    // the wiring against init (pid 1), which always runs as root.
+    auto p = new Process(1);
+    assert(p.isRoot());
+}

--- a/source/gx/tilix/terminal/activeprocess.d
+++ b/source/gx/tilix/terminal/activeprocess.d
@@ -11,6 +11,8 @@ import std.file;
 import std.path;
 import std.string;
 
+import gx.util.proc : readProcStatus;
+
 
 /**
 * A stripped-down (plus extended) version of psutil's Process class.
@@ -36,26 +38,9 @@ class Process {
         return to!pid_t(processStat[2]);
     }
 
-    /**
-     * Returns true if the process is running as root (effective UID == 0).
-     * Reads the Uid line from /proc/[PID]/status which has the format:
-     * Uid: real effective saved filesystem
-     */
+    /// True if the process has effective UID 0 (root).
     bool isRoot() {
-        try {
-            string data = to!string(cast(char[]) read(format("/proc/%d/status", pid)));
-            foreach (line; data.splitLines()) {
-                if (line.startsWith("Uid:")) {
-                    auto fields = line.split();
-                    if (fields.length >= 3) {
-                        return fields[2] == "0"; // effective UID
-                    }
-                }
-            }
-        } catch (FileException fe) {
-            // Process may have exited
-        }
-        return false;
+        return readProcStatus(pid).uid == 0;
     }
 
     string[] parseStatFile() {

--- a/source/gx/tilix/terminal/monitor.d
+++ b/source/gx/tilix/terminal/monitor.d
@@ -21,6 +21,8 @@ import gx.tilix.common;
 import gx.tilix.constants;
 import gx.tilix.terminal.activeprocess;
 
+import gx.util.proc : checkProcessTreeForRoot, isSSHProcess;
+
 import gx.tilix.application;
 
 enum MonitorEventType {
@@ -151,60 +153,6 @@ enum SLEEP_CONSTANT_MS = 300;
  */
 shared ProcessStatus[GPid] processes;
 
-/**
- * Walk up the process tree from the given PID, checking if any
- * process has effective UID 0 (root). Stops at init (pid 1) or
- * when the process no longer exists.
- */
-bool checkProcessTreeForRoot(pid_t startPid) {
-    import std.conv : to;
-    import std.file : read, exists;
-    import std.format : format;
-    import std.string : splitLines, startsWith, split;
-
-    pid_t currentPid = startPid;
-    for (int depth = 0; depth < 10; depth++) {
-        if (currentPid <= 1) break;
-        auto path = format("/proc/%d/status", currentPid);
-        if (!exists(path)) break;
-        try {
-            string data = to!string(cast(char[]) read(path));
-            pid_t ppid = 0;
-            foreach (line; data.splitLines()) {
-                if (line.startsWith("Uid:")) {
-                    auto fields = line.split();
-                    if (fields.length >= 3 && fields[2] == "0") {
-                        return true;
-                    }
-                }
-                if (line.startsWith("PPid:")) {
-                    auto fields = line.split();
-                    if (fields.length >= 2) {
-                        ppid = to!pid_t(fields[1]);
-                    }
-                }
-            }
-            currentPid = ppid;
-        } catch (Exception e) {
-            break;
-        }
-    }
-    return false;
-}
-
-/**
- * SSH-related process names that indicate a remote connection.
- */
-immutable string[] SSH_PROCESS_NAMES = ["ssh", "scp", "sftp", "mosh", "sshfs"];
-
-/**
- * Returns true if the given process name indicates an SSH session.
- */
-bool isSSHProcess(string name) {
-    import std.algorithm : canFind;
-    return SSH_PROCESS_NAMES.canFind(name);
-}
-
 void monitorProcesses(int sleep, Tid tid) {
     bool abort = false;
     while (!abort) {
@@ -261,23 +209,6 @@ shared class ProcessStatus {
 }
 
 // -- Unit tests --
-
-unittest {
-    // SSH process detection
-    assert(isSSHProcess("ssh"));
-    assert(isSSHProcess("scp"));
-    assert(isSSHProcess("sftp"));
-    assert(isSSHProcess("mosh"));
-    assert(isSSHProcess("sshfs"));
-
-    // Non-SSH processes
-    assert(!isSSHProcess("bash"));
-    assert(!isSSHProcess("vim"));
-    assert(!isSSHProcess("sudo"));
-    assert(!isSSHProcess("sshd"));  // daemon, not client
-    assert(!isSSHProcess("ssh-agent"));
-    assert(!isSSHProcess(""));
-}
 
 unittest {
     // ProcessInfo struct construction

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -130,6 +130,7 @@ import gx.gtk.vte;
 import gx.i18n.l10n;
 import gx.util.array;
 import gx.util.redact : stripUrlUserinfo;
+import gx.util.string : parsePairs;
 
 import gx.tilix.application;
 import gx.tilix.bookmark.bmchooser;
@@ -1604,23 +1605,12 @@ private:
      */
     void processTrigger(TerminalTrigger trigger, string[] groups) {
 
-        string[string] getParameters(string triggerParameters) {
-            string[string] result;
-            foreach (parameter; split(replaceMatchTokens(triggerParameters, groups), ";")) {
-                string[] pair = split(parameter, "=");
-                if (pair.length == 2) {
-                    result[pair[0].strip()] = pair[1].strip();
-                }
-            }
-            return result;
-        }
-
         // replace various variable tokens in parameters, i.e. ${rows}, ${title}, etc
         trigger.parameters = replaceVariables(trigger.parameters);
 
         final switch (trigger.action) {
             case TriggerAction.UPDATE_STATE:
-                string[string] parameters = getParameters(trigger.parameters);
+                string[string] parameters = parsePairs(replaceMatchTokens(trigger.parameters, groups));
                 bool update = false;
                 foreach (variable; EnumMembers!(GlobalTerminalState.StateVariable)) {
                     if (variable in parameters) {
@@ -1638,7 +1628,7 @@ private:
                 spawnShell(replaceMatchTokens(trigger.parameters, groups));
                 break;
             case TriggerAction.SEND_NOTIFICATION:
-                string[string] parameters = getParameters(trigger.parameters);
+                string[string] parameters = parsePairs(replaceMatchTokens(trigger.parameters, groups));
                 tracef("Parameters count: %d", parameters.length);
                 string title = _("ttyx_ Custom Notification");
                 string _body;

--- a/source/gx/util/proc.d
+++ b/source/gx/util/proc.d
@@ -37,7 +37,7 @@ ProcStatus readProcStatus(pid_t pid) {
     import std.string : splitLines, startsWith, split;
 
     if (pid <= 0) return ProcStatus.init;
-    auto path = format("/proc/%d/status", pid);
+    string path = format("/proc/%d/status", pid);
     if (!exists(path)) return ProcStatus.init;
     try {
         string data = to!string(cast(char[]) read(path));
@@ -45,13 +45,13 @@ ProcStatus readProcStatus(pid_t pid) {
         bool sawUid = false;
         foreach (line; data.splitLines()) {
             if (line.startsWith("Uid:")) {
-                auto fields = line.split();
+                string[] fields = line.split();
                 if (fields.length >= 3) {
                     result.uid = to!int(fields[2]);
                     sawUid = true;
                 }
             } else if (line.startsWith("PPid:")) {
-                auto fields = line.split();
+                string[] fields = line.split();
                 if (fields.length >= 2) {
                     result.ppid = to!pid_t(fields[1]);
                 }
@@ -74,7 +74,7 @@ bool checkProcessTreeForRoot(pid_t startPid) {
     pid_t currentPid = startPid;
     for (int depth = 0; depth < 10; depth++) {
         if (currentPid <= 1) break;
-        auto status = readProcStatus(currentPid);
+        ProcStatus status = readProcStatus(currentPid);
         if (!status.isValid()) break;
         if (status.uid == 0) return true;
         currentPid = status.ppid;
@@ -109,7 +109,7 @@ unittest {
 
 unittest {
     // Init (pid 1) always runs as root on Linux and has no parent.
-    auto s = readProcStatus(1);
+    ProcStatus s = readProcStatus(1);
     assert(s.isValid());
     assert(s.uid == 0);
     assert(s.ppid == 0);
@@ -118,7 +118,7 @@ unittest {
 unittest {
     // The current process exists and is parseable.
     import core.sys.posix.unistd : getpid;
-    auto s = readProcStatus(getpid());
+    ProcStatus s = readProcStatus(getpid());
     assert(s.isValid());
     assert(s.ppid > 0);
 }

--- a/source/gx/util/proc.d
+++ b/source/gx/util/proc.d
@@ -108,10 +108,11 @@ unittest {
 }
 
 unittest {
-    // Init (pid 1) always runs as root on Linux.
+    // Init (pid 1) always runs as root on Linux and has no parent.
     auto s = readProcStatus(1);
     assert(s.isValid());
     assert(s.uid == 0);
+    assert(s.ppid == 0);
 }
 
 unittest {

--- a/source/gx/util/proc.d
+++ b/source/gx/util/proc.d
@@ -1,0 +1,148 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+ * distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+module gx.util.proc;
+
+import core.sys.posix.unistd : pid_t;
+
+/// SSH-family process names that indicate a remote connection.
+immutable string[] SSH_PROCESS_NAMES = ["ssh", "scp", "sftp", "mosh", "sshfs"];
+
+/// Returns true if `name` is one of the SSH-family commands.
+bool isSSHProcess(string name) {
+    import std.algorithm : canFind;
+    return SSH_PROCESS_NAMES.canFind(name);
+}
+
+/// Parsed fields from `/proc/[pid]/status` that we care about.
+/// `uid` is the effective UID; -1 signals a read/parse failure.
+struct ProcStatus {
+    int uid = -1;
+    pid_t ppid = 0;
+
+    bool isValid() const { return uid >= 0; }
+}
+
+/**
+ * Read `/proc/[pid]/status` and return the effective UID + PPid.
+ * Returns `ProcStatus.init` (uid = -1) if the file is missing,
+ * unreadable, or malformed.
+ */
+ProcStatus readProcStatus(pid_t pid) {
+    import std.conv : to;
+    import std.file : read, exists;
+    import std.format : format;
+    import std.string : splitLines, startsWith, split;
+
+    if (pid <= 0) return ProcStatus.init;
+    auto path = format("/proc/%d/status", pid);
+    if (!exists(path)) return ProcStatus.init;
+    try {
+        string data = to!string(cast(char[]) read(path));
+        ProcStatus result;
+        bool sawUid = false;
+        foreach (line; data.splitLines()) {
+            if (line.startsWith("Uid:")) {
+                auto fields = line.split();
+                if (fields.length >= 3) {
+                    result.uid = to!int(fields[2]);
+                    sawUid = true;
+                }
+            } else if (line.startsWith("PPid:")) {
+                auto fields = line.split();
+                if (fields.length >= 2) {
+                    result.ppid = to!pid_t(fields[1]);
+                }
+            }
+        }
+        return sawUid ? result : ProcStatus.init;
+    } catch (Exception) {
+        return ProcStatus.init;
+    }
+}
+
+/**
+ * Walk up the process tree from `startPid`, returning true if any
+ * non-init ancestor has effective UID 0 (root). Stops at pid <= 1
+ * or when a process in the chain no longer exists. Bounded depth
+ * prevents pathological loops (shouldn't happen on a sane system
+ * but guards against surprises).
+ */
+bool checkProcessTreeForRoot(pid_t startPid) {
+    pid_t currentPid = startPid;
+    for (int depth = 0; depth < 10; depth++) {
+        if (currentPid <= 1) break;
+        auto status = readProcStatus(currentPid);
+        if (!status.isValid()) break;
+        if (status.uid == 0) return true;
+        currentPid = status.ppid;
+    }
+    return false;
+}
+
+// -- tests --------------------------------------------------------------
+
+unittest {
+    // SSH process detection
+    assert(isSSHProcess("ssh"));
+    assert(isSSHProcess("scp"));
+    assert(isSSHProcess("sftp"));
+    assert(isSSHProcess("mosh"));
+    assert(isSSHProcess("sshfs"));
+
+    assert(!isSSHProcess("bash"));
+    assert(!isSSHProcess("vim"));
+    assert(!isSSHProcess("sudo"));
+    assert(!isSSHProcess("sshd"));      // daemon, not client
+    assert(!isSSHProcess("ssh-agent"));
+    assert(!isSSHProcess(""));
+}
+
+unittest {
+    // ProcStatus default is invalid.
+    auto s = ProcStatus.init;
+    assert(!s.isValid());
+    assert(s.uid == -1);
+}
+
+unittest {
+    // Init (pid 1) always runs as root on Linux.
+    auto s = readProcStatus(1);
+    assert(s.isValid());
+    assert(s.uid == 0);
+}
+
+unittest {
+    // The current process exists and is parseable.
+    import core.sys.posix.unistd : getpid;
+    auto s = readProcStatus(getpid());
+    assert(s.isValid());
+    assert(s.ppid > 0);
+}
+
+unittest {
+    // Non-existent / invalid pids return the invalid sentinel.
+    assert(!readProcStatus(999_999_999).isValid());
+    assert(!readProcStatus(0).isValid());
+    assert(!readProcStatus(-1).isValid());
+}
+
+unittest {
+    // checkProcessTreeForRoot skips init and invalid pids by guard.
+    assert(!checkProcessTreeForRoot(1));
+    assert(!checkProcessTreeForRoot(0));
+    assert(!checkProcessTreeForRoot(-1));
+    assert(!checkProcessTreeForRoot(999_999_999));
+}
+
+unittest {
+    // If the test runner itself isn't root, walking up from the
+    // current PID must return false. If it is root, the result is
+    // true and we skip the assertion to keep the test portable.
+    import core.sys.posix.unistd : getpid, geteuid;
+    if (geteuid() != 0) {
+        assert(!checkProcessTreeForRoot(getpid()));
+    }
+}

--- a/source/gx/util/string.d
+++ b/source/gx/util/string.d
@@ -56,3 +56,84 @@ unittest {
     // Then: has comma and "" → wrapped: "a,""b"""
     assert(result == "\"a,\"\"b\"\"\"");
 }
+
+/**
+ * Parse a `pairSep`-delimited string of `kvSep`-separated key=value
+ * pairs into a map. Whitespace around keys and values is trimmed.
+ * Chunks without a `kvSep` are silently skipped. Duplicate keys: the
+ * last occurrence wins.
+ *
+ * Example: `parsePairs("a=1;b=2")` → `["a": "1", "b": "2"]`.
+ */
+string[string] parsePairs(string input, string pairSep = ";", string kvSep = "=") {
+    string[string] result;
+    if (input.length == 0) return result;
+    foreach (chunk; input.split(pairSep)) {
+        auto idx = chunk.indexOf(kvSep);
+        if (idx < 0) continue;
+        string key = chunk[0 .. idx].strip();
+        string value = chunk[idx + kvSep.length .. $].strip();
+        result[key] = value;
+    }
+    return result;
+}
+
+/// Test: single and multiple pairs, default separators.
+unittest {
+    auto m = parsePairs("a=1");
+    assert(m.length == 1 && m["a"] == "1");
+
+    m = parsePairs("a=1;b=2;c=3");
+    assert(m.length == 3);
+    assert(m["a"] == "1" && m["b"] == "2" && m["c"] == "3");
+}
+
+/// Test: whitespace around keys and values is trimmed.
+unittest {
+    auto m = parsePairs("  a  = 1 ; b=  foo bar  ");
+    assert(m["a"] == "1");
+    assert(m["b"] == "foo bar"); // internal whitespace preserved
+}
+
+/// Test: chunks without a kvSep are skipped silently.
+unittest {
+    auto m = parsePairs("a=1;broken;b=2");
+    assert(m.length == 2);
+    assert(m["a"] == "1" && m["b"] == "2");
+}
+
+/// Test: empty input and degenerate shapes.
+unittest {
+    assert(parsePairs("").length == 0);
+    assert(parsePairs(";;;").length == 0);
+    auto m = parsePairs("=value");  // empty key retained
+    assert(m.length == 1 && m[""] == "value");
+    m = parsePairs("key=");         // empty value retained
+    assert(m.length == 1 && m["key"] == "");
+}
+
+/// Test: trailing/leading separator is tolerated.
+unittest {
+    auto m = parsePairs(";a=1;b=2;");
+    assert(m.length == 2);
+    assert(m["a"] == "1" && m["b"] == "2");
+}
+
+/// Test: duplicate keys — last wins.
+unittest {
+    auto m = parsePairs("a=1;a=2;a=3");
+    assert(m["a"] == "3");
+}
+
+/// Test: the value may itself contain `=`; only the first separator splits.
+unittest {
+    auto m = parsePairs("url=http://x.example/?q=1&r=2");
+    assert(m["url"] == "http://x.example/?q=1&r=2");
+}
+
+/// Test: custom separators (non-default).
+unittest {
+    auto m = parsePairs("a:1,b:2,c:3", ",", ":");
+    assert(m.length == 3);
+    assert(m["a"] == "1" && m["b"] == "2" && m["c"] == "3");
+}

--- a/source/gx/util/string.d
+++ b/source/gx/util/string.d
@@ -69,7 +69,7 @@ string[string] parsePairs(string input, string pairSep = ";", string kvSep = "="
     string[string] result;
     if (input.length == 0) return result;
     foreach (chunk; input.split(pairSep)) {
-        auto idx = chunk.indexOf(kvSep);
+        ptrdiff_t idx = chunk.indexOf(kvSep);
         if (idx < 0) continue;
         string key = chunk[0 .. idx].strip();
         string value = chunk[idx + kvSep.length .. $].strip();
@@ -80,7 +80,7 @@ string[string] parsePairs(string input, string pairSep = ";", string kvSep = "="
 
 /// Test: single and multiple pairs, default separators.
 unittest {
-    auto m = parsePairs("a=1");
+    string[string] m = parsePairs("a=1");
     assert(m.length == 1 && m["a"] == "1");
 
     m = parsePairs("a=1;b=2;c=3");
@@ -90,14 +90,14 @@ unittest {
 
 /// Test: whitespace around keys and values is trimmed.
 unittest {
-    auto m = parsePairs("  a  = 1 ; b=  foo bar  ");
+    string[string] m = parsePairs("  a  = 1 ; b=  foo bar  ");
     assert(m["a"] == "1");
     assert(m["b"] == "foo bar"); // internal whitespace preserved
 }
 
 /// Test: chunks without a kvSep are skipped silently.
 unittest {
-    auto m = parsePairs("a=1;broken;b=2");
+    string[string] m = parsePairs("a=1;broken;b=2");
     assert(m.length == 2);
     assert(m["a"] == "1" && m["b"] == "2");
 }
@@ -106,7 +106,7 @@ unittest {
 unittest {
     assert(parsePairs("").length == 0);
     assert(parsePairs(";;;").length == 0);
-    auto m = parsePairs("=value");  // empty key retained
+    string[string] m = parsePairs("=value");  // empty key retained
     assert(m.length == 1 && m[""] == "value");
     m = parsePairs("key=");         // empty value retained
     assert(m.length == 1 && m["key"] == "");
@@ -114,33 +114,33 @@ unittest {
 
 /// Test: trailing/leading separator is tolerated.
 unittest {
-    auto m = parsePairs(";a=1;b=2;");
+    string[string] m = parsePairs(";a=1;b=2;");
     assert(m.length == 2);
     assert(m["a"] == "1" && m["b"] == "2");
 }
 
 /// Test: duplicate keys — last wins.
 unittest {
-    auto m = parsePairs("a=1;a=2;a=3");
+    string[string] m = parsePairs("a=1;a=2;a=3");
     assert(m["a"] == "3");
 }
 
 /// Test: the value may itself contain `=`; only the first separator splits.
 unittest {
-    auto m = parsePairs("url=http://x.example/?q=1&r=2");
+    string[string] m = parsePairs("url=http://x.example/?q=1&r=2");
     assert(m["url"] == "http://x.example/?q=1&r=2");
 }
 
 /// Test: custom separators (non-default).
 unittest {
-    auto m = parsePairs("a:1,b:2,c:3", ",", ":");
+    string[string] m = parsePairs("a:1,b:2,c:3", ",", ":");
     assert(m.length == 3);
     assert(m["a"] == "1" && m["b"] == "2" && m["c"] == "3");
 }
 
 /// Test: multi-character separators (verifies kvSep.length is used, not +1).
 unittest {
-    auto m = parsePairs("a => 1 || b => 2", "||", "=>");
+    string[string] m = parsePairs("a => 1 || b => 2", "||", "=>");
     assert(m.length == 2);
     assert(m["a"] == "1" && m["b"] == "2");
 }
@@ -150,7 +150,7 @@ unittest {
 /// containing two or more `=` characters. parsePairs preserves such
 /// inputs by splitting at the first kvSep only.
 unittest {
-    auto m = parsePairs("a==b");
+    string[string] m = parsePairs("a==b");
     assert(m.length == 1);
     assert(m["a"] == "=b");
 }

--- a/source/gx/util/string.d
+++ b/source/gx/util/string.d
@@ -137,3 +137,20 @@ unittest {
     assert(m.length == 3);
     assert(m["a"] == "1" && m["b"] == "2" && m["c"] == "3");
 }
+
+/// Test: multi-character separators (verifies kvSep.length is used, not +1).
+unittest {
+    auto m = parsePairs("a => 1 || b => 2", "||", "=>");
+    assert(m.length == 2);
+    assert(m["a"] == "1" && m["b"] == "2");
+}
+
+/// Test: regression anchor — the old nested getParameters used
+/// `pair.length == 2` after split("="), which dropped any input
+/// containing two or more `=` characters. parsePairs preserves such
+/// inputs by splitting at the first kvSep only.
+unittest {
+    auto m = parsePairs("a==b");
+    assert(m.length == 1);
+    assert(m["a"] == "=b");
+}


### PR DESCRIPTION
Two related lifts out of `terminal.d` / `monitor.d` / `activeprocess.d` into the `gx/util/` namespace. Candidate 2 and widened candidate 3 from our offline discussion on reducing terminal.d complexity and unlocking tests for previously-untested logic.

## Commit 1 — `parsePairs` → `gx.util.string`

The trigger-parameter parser (`key=value;key=value;…`) was a nested function inside `processTrigger` at `terminal.d:1607`. Pure string logic trapped in a 178KB GTK widget file, unreachable from tests without spinning up a Terminal instance.

New helper: `string[string] parsePairs(string input, string pairSep = ";", string kvSep = "=")`.

Callers:
- `terminal.d:1623` and `:1641` both did `getParameters(trigger.parameters)`. They now do `parsePairs(replaceMatchTokens(trigger.parameters, groups))` directly — composable and explicit.

**Minor behavior improvement:** the nested version used `split(parameter, "=")` and required `pair.length == 2`, silently dropping any pair whose value contained `=` (e.g. a URL or a query-string-shaped notification body). `parsePairs` splits at the first `kvSep`, so values containing `=` are preserved. Strictly more permissive — no regression for the existing trigger use cases (StateVariable keys and title/body strings).

Nine new unit tests: single/multiple pairs, whitespace trimming, chunks missing `kvSep` (skipped), empty/degenerate input, leading/trailing separator, duplicate keys (last wins), values containing `kvSep`, and custom separator characters.

## Commit 2 — process introspection consolidation → new `gx.util.proc`

Two places parsed `/proc/[pid]/status` to read the effective UID:
- `checkProcessTreeForRoot` in `monitor.d` (walking the ancestor chain)
- `Process.isRoot()` in `activeprocess.d` (single-process check)

Both duplicated the same `splitLines` / `startsWith("Uid:")` / `split` / `fields[2]` pattern.

New module contents:
- `SSH_PROCESS_NAMES` + `isSSHProcess` (moved from `monitor.d`, existing unittests relocate with them — no coverage loss)
- `ProcStatus { int uid = -1; pid_t ppid = 0; }` with `isValid()`
- `readProcStatus(pid_t)` — the single `/proc/[pid]/status` parser, returns invalid sentinel on read/parse failure
- `checkProcessTreeForRoot(pid_t)` — rewritten on top of `readProcStatus`

`Process.isRoot()` shrinks to one line:
```d
return readProcStatus(pid).uid == 0;
```

**Six new unit tests for the proc helpers** (the real coverage win — these paths were previously untested):
- `readProcStatus(1).uid == 0` (init is always root on Linux)
- `readProcStatus(getpid())` is valid and has a ppid
- `readProcStatus(999_999_999)`, `readProcStatus(0)`, `readProcStatus(-1)` all return the invalid sentinel
- `checkProcessTreeForRoot(1 / 0 / -1 / 999_999_999)` all return false via the guards
- `checkProcessTreeForRoot(getpid()) == false` guarded on `geteuid() != 0` so the test is portable across runners

## Scope boundary

I did **not** move the `Process` class, `getForegroundProcess`, `getActiveProcessList`, or the static `processMap/sessionMap` state out of `activeprocess.d`. Those carry class-level mutable state and are specific to the monitor. Util modules shouldn't hold app-global state.

## Test plan

- [x] `meson test -C builddir` passes (28 modules passed unittests, was 26 before commit 1)
- [ ] Manual: not required — refactors only, algorithms preserved

## Motivation

Three criteria guide the extractions:
1. **Deduplication**: applies to commit 2 (Uid parsing duplicated)
2. **Host-module clarity**: applies to commit 1 (terminal.d loses a nested function)
3. **Testability unlock**: applies to both — neither extracted function could previously be exercised without a Terminal or Process instance

Assisted by Claude Code.