### PR TITLE
docs: Publish manual via GitHub Pages (just-the-docs)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,33 @@
+title: ttyx_
+description: Documentation for ttyx_, a tiling terminal emulator for Linux
+baseurl: "/ttyx_"
+url: "https://gwelr.github.io"
+
+remote_theme: just-the-docs/just-the-docs
+
+# Theme settings
+color_scheme: light
+search_enabled: true
+search:
+  heading_level: 3
+  previews: 3
+  preview_words_before: 5
+  preview_words_after: 10
+  tokenizer_separator: /[\s\-/]+/
+  rel_url: true
+  button: false
+
+# Navigation
+heading_anchors: true
+nav_external_links:
+  - title: ttyx_ on GitHub
+    url: https://github.com/gwelr/ttyx_
+    hide_icon: false
+
+# Footer
+footer_content: "Manual content adapted from the original <a href=\"https://github.com/gnunn1/tilix\">Tilix</a> by Gerald Nunn under <a href=\"https://github.com/gwelr/ttyx_/blob/master/LICENSE\">MPL-2.0</a>."
+
+# Jekyll settings
+permalink: pretty
+exclude:
+  - README.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,36 @@
+---
+title: Home
+layout: home
+nav_order: 1
+---
+
+# ttyx_
+
+**Tilix, but with a pulse.**
+
+ttyx_ is an actively maintained fork of [Tilix](https://github.com/gnunn1/tilix), the tiling terminal emulator for Linux. The original project did amazing work but, with development stalled and a growing list of unaddressed bugs, ttyx_ picks up where it left off.
+
+## Getting started
+
+- [Download & install](https://github.com/gwelr/ttyx_#building)
+- [What's new in ttyx_ since Tilix](https://github.com/gwelr/ttyx_#whats-new-since-tilix)
+- [Report an issue](https://github.com/gwelr/ttyx_/issues)
+
+## Documentation
+
+The [Manual]({{ site.baseurl }}/manual/) covers the main feature areas:
+
+- **Titles & variables** — customize window, session, and terminal titles with runtime variables
+- **Quake mode** — drop-down terminal activated by a global hot key
+- **Triggers** — react to terminal output with regex-driven actions
+- **Color schemes & themes** — switch and author color schemes
+- **Badges** — overlay status information on a terminal
+- **Profile switching** — swap profiles based on hostname or working directory
+- **Custom links** — make your own clickable patterns in terminal output
+- **Margin indicators** — visual markers at column positions
+- **VTE configuration** — low-level terminal emulator tuning
+- **CLI actions** — invoke ttyx_ actions from the command line
+
+## About this documentation
+
+Much of the manual content originated in Gerald Nunn's [Tilix](https://github.com/gnunn1/tilix) and is reused under [MPL-2.0](https://github.com/gwelr/ttyx_/blob/master/LICENSE). Some pages still reference "Tilix" where the wording hasn't been updated yet — corrections welcome via pull request.

--- a/docs/manual/badges.md
+++ b/docs/manual/badges.md
@@ -1,0 +1,15 @@
+---
+title: Badges
+parent: Manual
+nav_order: 5
+layout: default
+---
+
+
+![]({{site.baseurl}}/assets/images/manual/badges.png)
+
+Badges are a feature that displays specified text in the background of the terminal. They can be used for a variety of purposes including acting as visual reminders or as a way to display the terminal title when the title is disabled.
+
+Badges are configured at the Profile level and are specific to a Profile. The General page of Profile preferences allows you to specify the badge text and the position of the badge. Note that badges support all of the same variables as terminal titles, so you can specify something like ```${title}``` to display the title in the badge. See the FAQ for a list of variables that are available.
+
+The color of the badge can be configured in the Colors page of Profile preferences and is nested within the Advanced popup. Additionally, the badge color can be specified in the theme files.

--- a/docs/manual/cliactions.md
+++ b/docs/manual/cliactions.md
@@ -1,0 +1,30 @@
+---
+title: Command Line Actions
+parent: Manual
+nav_order: 10
+layout: default
+---
+
+#### Introduction
+
+Tilix supports the use of command line actions to have the running instance execute an action that you would typically do through the user interface. The use case for this functionality is to be able run a script within tilix that causes it to perform certain commands. For example, to have Tilix run the command ```yaourt -Syua``` in a new terminal that is split right, the following command can be used:
+
+
+{% highlight bash %}
+tilix -a session-add-right -x "yaourt -Syua"
+{% endhighlight %}
+
+The ```-a```, or ```--action```, command line switch is what is used to specify the action to be executed. Any action executed is always done relative to the terminal where the command was executed. Any command line parameters that are specified as part of the command get passed to the new terminal. This allows you to do a variety of things such as use a different profile, specify the working directory or as per the example above, execute a command.
+
+#### Supported Actions
+
+The actions are specified using the same keys you see in dconf for the key shortcuts at ```/com/gexperts/Tilix/keybindings```. While any action shown here can be sent via the action parameter, not all of them are supported or will work. Some of the actions, such as Synchronize Input, would require additional parameters to function correctly.
+
+The table below is the list of officially supported actions at this time:
+
+Action | Description
+-------|------------
+session-add-right | Splits the terminal right
+session-add-down | Splits the terminal down
+app-new-window | Creates a new Tilix window
+app-new-session | Creates a new Tilix session

--- a/docs/manual/customlinks.md
+++ b/docs/manual/customlinks.md
@@ -1,0 +1,14 @@
+---
+title: Custom Hyperlinks
+parent: Manual
+nav_order: 7
+layout: default
+---
+
+Tilix allows custom hyperlinks to be defined using regular expressions. These links can then be clicked on to launch an application passing information from the match to the application.
+
+When configuring the application to be launched, the token ```$0``` can be used to represent the match obtained from the regular expression. If the regular expression includes groups then ```$1``` is the first group, ```$2``` the second group, etc.
+
+Here is a screenshot showing an example of using this feature to launch gedit with the filename and line number based on a regular expression that includes two groups.
+
+![]({{site.baseurl}}/assets/images/manual/links.png)

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -1,0 +1,24 @@
+---
+title: Manual
+layout: default
+nav_order: 2
+has_children: true
+permalink: /manual/
+---
+
+# Manual
+
+Topic-by-topic reference for ttyx_ features. Content adapted from the [Tilix manual](https://gnunn1.github.io/tilix-web/manual/) by Gerald Nunn.
+
+## Contents
+
+- [Titles]({{ site.baseurl }}/manual/title/) — customize window, session, and terminal titles with runtime variables
+- [Quake mode]({{ site.baseurl }}/manual/quake/) — drop-down terminal triggered by a global hot key
+- [Triggers]({{ site.baseurl }}/manual/triggers/) — react to terminal output with regex-driven actions
+- [Themes]({{ site.baseurl }}/manual/themes/) — color schemes and light/dark mode behaviour
+- [Badges]({{ site.baseurl }}/manual/badges/) — overlay information on a terminal
+- [Profile switching]({{ site.baseurl }}/manual/profileswitch/) — swap profiles based on hostname or working directory
+- [Custom links]({{ site.baseurl }}/manual/customlinks/) — make your own clickable patterns in terminal output
+- [Margin indicators]({{ site.baseurl }}/manual/margin/) — visual markers at column positions
+- [VTE configuration]({{ site.baseurl }}/manual/vteconfig/) — low-level terminal emulator tuning
+- [CLI actions]({{ site.baseurl }}/manual/cliactions/) — invoke ttyx_ actions from the command line

--- a/docs/manual/margin.md
+++ b/docs/manual/margin.md
@@ -1,0 +1,12 @@
+---
+title: Margin
+parent: Manual
+nav_order: 8
+layout: default
+---
+
+![]({{site.baseurl}}/assets/images/manual/margin.png)
+
+Many code standards require line length always be under a prescribed limit to maintain readability. When using text editors like vi, emacs or nano it can be useful to have a margin indicating where this limit is. Tilix allows you to configure the limit on a per profile basis and then toggle the margin line on or off via a shortcut. The default shortcut is ctrl-alt-m.
+
+This is available as of Tilix 1.8.1.

--- a/docs/manual/profileswitch.md
+++ b/docs/manual/profileswitch.md
@@ -1,0 +1,34 @@
+---
+title: Automatic Profile Switching
+parent: Manual
+nav_order: 6
+layout: default
+---
+
+#### Introduction
+
+Tilix supports automatically switching profiles based on certain conditions which is useful in a variety of situations such as when switching users, connecting to different hosts, changing to sensitive directories, etc. At the moment Tilix supports triggering a profile change based on the following:
+
+* username
+* hostname
+* current directory
+
+Note that when an automatic profile change is active, the menu to switch to different profiles will be disabled.
+
+#### Local Configuration
+
+Configuring profile switching in Tilix is done in the Advanced tab of the profile settings. Here you can configure the list of usernames, hostnames and directories that will trigger the profile change. The format used for the string is ```username@hostname:directory``` where either username, hostname or directory can be omitted but not all. Also at least one delimiter, either *@* or *:*, is also required to indicate which string is being represented.
+
+**Note** that switching profiles based on username requires the use of a trigger to extract the username from the terminal output text. Triggers in turn require a patched VTE, see the [Triggers](https://gnunn1.github.io/tilix-web/manual/triggers/) page for more information.
+
+#### Remote Configuration
+
+To enable profile changes when using SSH to connect to remote systems, the remote system must be configured to include an additional script or an appropriate trigger configured. 
+
+If you opt for the script, first scp the script ```/usr/share/tilix/scripts/tilix_int.sh``` from your local system where tilix is installed to the remote system. You will then need to source this script on the remote system, the easiest way to do this is to modify the .bashrc of the user you use to connect to include the script. For example, add the following to .bashrc:
+
+{% highlight bash %}
+. ./tilix_int.sh
+{% endhighlight %}
+
+if you switch users on the remote system, you may need to source the script somewhere so it is available to all users.

--- a/docs/manual/quake.md
+++ b/docs/manual/quake.md
@@ -1,0 +1,33 @@
+---
+title: Quake
+parent: Manual
+nav_order: 2
+layout: default
+---
+
+#### Introduction
+
+Tilix supports running in a _Quake_-style mode where it appears at the top of the screen and can be toggled on or off as needed. However, unlike other terminal emulators that support this mode Tilix does not register a global hot key. Instead you must register a hot key yourself with the Desktop Environment you are using, this is required because Wayland does not support global hot keys.
+
+When you register the hot key, simply bind it to the following command:
+
+{% highlight bash %}
+tilix --quake
+{% endhighlight %}
+
+When Tilix is run with the `--quake` switch, it will check if a quake style window is already running and if so simply toggle the window's visibility. If no quake style window has been created, then Tilix will create one and display it.
+
+Configuring this hot key for GNOME is quite simple, simply open the Keyboard settings and configure a hot key as per the example in the screenshot below:
+
+![]({{site.baseurl}}/assets/images/manual/hotkey.png)
+
+#### Wayland
+
+Note that quake mode in Wayland is currently not available, while initially supported it proved to be problematic given the limitations of the Wayland environment. Here are the options for enabling in Wayland:
+
+* Force the GDK back-end to be X11. You can force tilix to use X11 as the backend instead of Wayland by setting the quake command as ```GDK_BACKEND=x11 tilix --quake```. Note that you should also update the tilix desktop file to force the x11 backend as well.
+* There is a gnome-shell [quake](https://github.com/repsac-by/gnome-shell-extension-quake-mode) extension that enables any application to run in quake mode.
+
+### KDE
+
+If you have the issue where the tilix quake window does not receive focus, try disabling the feature "Focus stealing prevention" in KDE as per the comment [here](https://github.com/gnunn1/tilix/issues/895#issuecomment-385275324).

--- a/docs/manual/themes.md
+++ b/docs/manual/themes.md
@@ -1,0 +1,48 @@
+---
+title: Themes
+parent: Manual
+nav_order: 4
+layout: default
+---
+
+Tilix supports themes for configuring the color scheme of the terminal, each theme is stored in a file. A theme file is a simple json file that specifies the color for each element as well as identifying whether certain colors should be used or defaulted. Here is an example of a theme file:
+
+{% highlight json %}
+{
+    "name": "Orchis",
+    "comment": "Tango but using Orchis foreground/background colors",
+    "foreground-color": "#EFEFEF",
+    "background-color": "#303030",
+    "use-theme-colors": false,
+    "use-highlight-color": false,
+    "highlight-foreground-color": "#ffffff",
+    "highlight-background-color": "#a348b1",
+    "use-cursor-color": false,
+    "cursor-foreground-color": "#ffffff",
+    "cursor-background-color": "#efefef",
+    "use-badge-color": true,
+    "badge-color": "#ac7ea8",
+    "palette": [
+        "#000000",
+        "#CC0000",
+        "#4D9A05",
+        "#C3A000",
+        "#3464A3",
+        "#754F7B",
+        "#05979A",
+        "#D3D6CF",
+        "#545652",
+        "#EF2828",
+        "#89E234",
+        "#FBE84F",
+        "#729ECF",
+        "#AC7EA8",
+        "#34E2E2",
+        "#EDEDEB"
+    ]
+}
+{% endhighlight %}
+
+Themes are loaded from one of two places by Tilix. The first is ```/usr/share/tilix/schemes```, these are the themes that are shipped with Tilix. The second place that Tilix looks for theme files is in the user home directory, specifically ```~/.config/tilix/schemes```. Users can place any custom themes they want to use here.
+
+While Tilix only includes a small number of themes, additional themes can be easily downloaded and installed. For instance, there are a couple of GitHub repositories as [Tilix-Themes](https://github.com/storm119/Tilix-Themes) and [gogh-to-tilix](https://github.com/isacikgoz/gogh-to-tilix) which have various pre-built themes.

--- a/docs/manual/title.md
+++ b/docs/manual/title.md
@@ -1,0 +1,47 @@
+---
+title: Titles
+parent: Manual
+nav_order: 1
+layout: default
+---
+
+Tilix support using variables in the various titles and names it allows to be configured. This enables the title to better reflect the current state of the application, session or currently focused terminal. Variables are available within a particular scope and can always be used in higher scopes. For example, the ${title} is a terminal scope variable but can be used in session and application titles where it reflects the currently active terminal.
+
+Variables can be used in the following locations:
+
+* Window title
+* Session name
+* Terminal title
+* Badge
+* Custom links
+* Triggers
+
+The following variables are supported at **terminal** scope and are determined based on the currently focused terminal:
+
+Variable | Description
+-------|------------
+${title} | The title of the terminal as reported by the terminal
+${iconTitle} | The icon title of the terminal
+${id} | The numeric terminal ID (i.e. 1,2,3,4)
+${directory} | The current working directory in the terminal
+${columns} | The number of columns in the terminal
+${rows} | the number of rows in the terminal
+${hostname} | the hostname of the current session, availability dependent on the VTE script being configured on remote systems or triggers
+${username} | the current username, requires trigger support and an appropriate trigger be configured
+
+These variables are available at **session** scope:
+
+Variable | Description
+-------|------------
+${activeTerminalTitle} | The title of the current terminal with all variables substituted.
+${terminalCount} | The total number of terminals in the session
+${terminalNumber} | The number of the currently active terminal
+
+The following additional variables are supported in all titles except terminal titles:
+
+Variable | Description
+-------|------------
+${appName} | The name of the application, i.e. Tilix
+${sessionName} | The name of the session
+${sessionCount} | The total number of sessions
+${sessionNumber} | The number of the session, i.e. session 2 out of 4 active

--- a/docs/manual/triggers.md
+++ b/docs/manual/triggers.md
@@ -1,0 +1,53 @@
+---
+title: Triggers
+parent: Manual
+nav_order: 3
+layout: default
+---
+
+*Note that trigger support requires that the GTK VTE widget be built with a tilix specific [patch](https://github.com/gnunn1/tilix/blob/master/experimental/vte/alternate-screen.patch), otherwise triggers are disabled. Arch users can access this functionality by installing the [vte3-tilix-git](https://aur.archlinux.org/packages/vte3-tilix-git) package.*
+
+#### Introduction
+
+Tilix supports the concept of triggers, these are regular expressions defined by the user that when matched against text output by the terminal trigger an action. A trigger consists of a regular expression, the action to execute and a parameter string. Depending on the action, the parameter may not be used at all, may be a single string or a semi-colon delimited list of variables.
+
+The result of the regular expression can be referenced as tokens in the parameter, Tilix will substitute the tokens in the parameter prior to executing the action. The token $0 refers to the complete regular expression match. If groups were defined in the regular expression, the tokens $1, $2, $3, etc refer to the individual group captures.
+
+#### Supported Actions
+
+The following actions are supported by Tilix:
+
+Action | Description
+-------|------------
+Update State | This action updates the state that Tilix maintains about the terminal in terms of things like what directory or hostname is currently active in the terminal. The variables *username*, *hostname* and *directory* can be used to update the state respectively, these represent . See further below for an example of how to use this.
+Execute Command | This action executes the command provided in the parameter field.
+Send Notification | Sends a notification to the desktop environment. Two variables are supported by this action, *title* and *body*.
+Update Title | Updates the terminal title using the parameter field, it sets the override title specified in Layout Options.
+Play Bell | Plays the bell noise, this action takes no parameters
+Send Text | Sends the text in the parameter field to the terminal
+Insert Password | Shows the password manager to enable a password to be inserted into the terminal
+
+#### Options
+
+Tilix has an option to limit the number of lines that are checked for triggers, this is intended to improve performance on slower hardware. Every time a change happens in the terminal, this is reported to Tilix as a block of text. This block might consist of just a single character when the user is typing, or it might consist of several thousand lines when outputting a large text file via cat.
+
+In the later scenario, we may generally not be too interested in checking for triggers in all lines of text. When this option is active, Tilix will only check the lines changed from the end of the text. So for example, if a block of text consisting of 20,000 lines of text was received but the option limit was active at 256, only the last 256 lines would be checked.
+
+#### Examples
+
+Here are some examples to help you use this feature:
+
+Regular Expression | Action | Parameter | Description
+-------------------|--------|-----------|------------
+```^\[(?P&lt;user>.*)@(?P&lt;host>[-a-zA-Z0-9]*)``` | Update State | username=$1;hostname=$2 | Parses the username and hostname from a Linux prompt command that uses the following format: *[username@hostname directory]$*
+
+#### How It Works
+
+To get the most of out of this feature, it's important to understand how this works under the hood. As an overview, Tilix uses a GTK component called the VTE to perform the actual terminal emulation. When changes occur in the VTE, it triggers an event to notify Tilix but does not include any information about the change itself. In order to execute triggers, Tilix saves the current row and column reported by the VTE so that when the next change event happens only the delta is processed for triggers.
+
+This means that any change in the terminal will be processed but the grouping of these changes is entirely up to the VTE. For example, when typing text Tilix will run triggers against each character entered by the user individually, it does not run triggers against the full command. 
+
+When outputting large amounts of text, i.e. cat'ing a large file, the VTE tends to report changes in very large chunks. This makes perfect sense the VTE needs to maintain a certain level of performance and caps the framerate by omitting rendering of text when it is not needed. As a result, when the scrollback buffer is limited (default in Tilix is 8192), not all of the text may be available to Tilix since it has already scrolled out of range of the buffer.
+
+Thus if you want Tilix to process triggers for every line of text, you must set the scrollback buffer to unlimited and the trigger lines option to unlimited.
+

--- a/docs/manual/vteconfig.md
+++ b/docs/manual/vteconfig.md
@@ -1,0 +1,58 @@
+---
+title: VTE Configuration
+parent: Manual
+nav_order: 9
+layout: default
+---
+
+#### Background
+
+Tilix uses a GTK+ 3 widget called VTE (Virtual Terminal Emulator). The VTE widget was originally designed as the back-end for Gnome Terminal but was fortunately designed as a GTK widget so that other terminal emulator applications could leverage it instead of rolling their own. Many popular Linux terminal emulators use this component.
+
+One aspect of VTE configuration is the use of /etc/profile.d/vte.sh. The VTE uses this script to override the PROMPT_COMMAND in order to feed itself additional information via terminal control codes. In particular, this script is used to tell the VTE the current directory of the shell. Previously the VTE component used to read this from /proc/&lt;pid&gt;/cwd however according to [VTE upstream](https://bugzilla.gnome.org/show_bug.cgi?id=697475) there were a number of issues with this approach and hence the change to /etc/profile.d/vte.sh.
+
+The issue with this change though is that different distributions treat /etc/profile.d differently. The expectation is that when a shell is initiated all scripts in /etc/profile.d are executed. On Fedora, this works as expected for both login and non-login based shells. However, other distributions (Ubuntu and Arch at least) only execute scripts in /etc/profile.d for login shells. The problem with this is the default configuration for most terminal emulators using VTE, including Gnome Terminal and Tilix, is to not run the shell as a login shell.
+
+#### Impact
+
+This means that on some Linux distributions vte.sh never gets executed and VTE loses certain features that are dependent on the PROMPT_COMMAND. In particular, the two features that we know are impacted:
+
+* The current directory is never reported by VTE. This means when splitting terminals in Tilix instead of inheriting the directory from the current terminal the split terminal always opens in your home terminal. Gnome Terminal has the same issue when creating new tabs
+* The Fedora patched VTE that provides notification support depends on PROMPT_COMMAND, so this issue means notifications will not work.
+
+#### Fixing the issue
+
+Fortunately fixing this issue is quite easy, you can do either of the two options below.
+
+##### 1. Source vte.sh in bashrc
+
+Update ```~/.bashrc``` (or ```~/.zshrc``` if you are using zsh) to execute vte.sh directly, this involves adding the following line at the end of the file.
+{% highlight bash %}
+if [ $TILIX_ID ] || [ $VTE_VERSION ]; then
+        source /etc/profile.d/vte.sh
+fi
+{% endhighlight %}
+
+On Ubuntu (16.04 or 16.10), a symlink is probably missing. You can create it with: 
+{% highlight bash %}
+ln -s /etc/profile.d/vte-2.91.sh /etc/profile.d/vte.sh
+{% endhighlight %}
+If you use a custom `PROMPT_COMMAND` instead of simply overriding `PS1` you also
+need to update your `PROMPT_COMMAND` to append working directory information.
+This can be achieved by calling `__vte_osc7` which gets defined when you source
+`/etc/profile.d/vte-2.91.sh`.
+
+{% highlight bash %}
+function custom_prompt() {
+  __git_ps1 "\[\033[0;31m\]\u \[\033[0;36m\]\h:\w\[\033[00m\]" " \n\[\033[0;31m\]>\[\033[00m\] " " %s"
+  VTE_PWD_THING="$(__vte_osc7)"
+  PS1="$PS1$VTE_PWD_THING"
+}
+PROMPT_COMMAND=custom_prompt
+{% endhighlight %}
+
+##### 2. OR use a login shell
+
+Enable the option in your Tilix Profile (under Preferences) to use a login shell, the screenshot below shows the option that needs to be checked.
+
+![Profile - Command](https://gnunn1.github.io/tilix-web/assets/images/manual/tilix_login_shell.png)


### PR DESCRIPTION
Bootstraps a documentation site at `https://gwelr.github.io/ttyx_/` using the [just-the-docs](https://github.com/just-the-docs/just-the-docs) theme, served directly by GitHub Pages from the `docs/` folder.

## What's in

- `docs/_config.yml` — remote_theme config, search enabled, footer attribution to upstream Tilix (MPL-2.0).
- `docs/index.md` — landing page linking to the manual + external repo/issues.
- `docs/manual/` — 10 manual pages adapted from https://github.com/gnunn1/tilix-web's `_manual/` folder. Front matter rewritten for just-the-docs conventions (`parent: Manual`, `nav_order: N`, `layout: default`).
- `docs/manual/index.md` — manual table of contents.

Topic ordering in the sidebar (not alphabetical — ordered by feature flow):

1. Titles
2. Quake mode
3. Triggers
4. Themes
5. Badges
6. Profile switching
7. Custom links
8. Margin indicators
9. VTE configuration
10. CLI actions

## What's explicitly NOT in this PR

The manual body text is **unchanged** from upstream. That means:

- Prose still refers to the product as "Tilix".
- Example commands still show `tilix -a session-add-right …` (our binary is `ttyx`).
- GSettings paths still cite `com.gexperts.Tilix.*` (ours is `io.github.gwelr.ttyx.*`).
- Links point to upstream Tilix resources in a few places.

These are documented on the landing page and in the site footer as "content under adaptation." Fixing them is a follow-up content pass, out of scope for this PR whose goal is to get hosting live.

## Activation after merge

Repo **Settings → Pages**:
- Source: "Deploy from a branch"
- Branch: `master` / `docs` (folder)

Site publishes at `https://gwelr.github.io/ttyx_/` within a few minutes of first push.

## Branding later

When we want to theme the site:

- **Colors** → create `docs/_sass/color_schemes/ttyx.scss` overriding variables like `$body-background-color`, `$link-color`, `$sidebar-color`. Activate with `color_scheme: ttyx` in `_config.yml`.
- **Fonts** → override `$body-font-family` / `$mono-font-family` in `docs/_sass/custom/setup.scss`. Add a Google Fonts `<link>` via `docs/_includes/head_custom.html` if using a webfont.
- **Dark mode** → `color_scheme: dark` in `_config.yml`.

No theme fork, no npm, no build pipeline — just SCSS variables.

## Attribution

Footer on every page credits Gerald Nunn's original Tilix work under MPL-2.0 with a direct link back to the upstream repo.

## Test plan

- [ ] Merge PR
- [ ] Enable Pages in repo settings (docs folder, master branch)
- [ ] Verify site loads at `https://gwelr.github.io/ttyx_/`
- [ ] Verify sidebar navigation, client-side search, and all 10 manual pages render

Assisted by Claude Code.