### PR TITLE
docs: Rename Tilix to ttyx_ through the manual content

### DIFF
--- a/docs/manual/cliactions.md
+++ b/docs/manual/cliactions.md
@@ -7,18 +7,18 @@ layout: default
 
 #### Introduction
 
-Tilix supports the use of command line actions to have the running instance execute an action that you would typically do through the user interface. The use case for this functionality is to be able run a script within tilix that causes it to perform certain commands. For example, to have Tilix run the command ```yaourt -Syua``` in a new terminal that is split right, the following command can be used:
+ttyx_ supports the use of command line actions to have the running instance execute an action that you would typically do through the user interface. The use case for this functionality is to be able run a script within ttyx_ that causes it to perform certain commands. For example, to have ttyx_ run the command ```yaourt -Syua``` in a new terminal that is split right, the following command can be used:
 
 
 {% highlight bash %}
-tilix -a session-add-right -x "yaourt -Syua"
+ttyx -a session-add-right -x "yaourt -Syua"
 {% endhighlight %}
 
 The ```-a```, or ```--action```, command line switch is what is used to specify the action to be executed. Any action executed is always done relative to the terminal where the command was executed. Any command line parameters that are specified as part of the command get passed to the new terminal. This allows you to do a variety of things such as use a different profile, specify the working directory or as per the example above, execute a command.
 
 #### Supported Actions
 
-The actions are specified using the same keys you see in dconf for the key shortcuts at ```/com/gexperts/Tilix/keybindings```. While any action shown here can be sent via the action parameter, not all of them are supported or will work. Some of the actions, such as Synchronize Input, would require additional parameters to function correctly.
+The actions are specified using the same keys you see in dconf for the key shortcuts at ```/io/github/gwelr/ttyx/keybindings```. While any action shown here can be sent via the action parameter, not all of them are supported or will work. Some of the actions, such as Synchronize Input, would require additional parameters to function correctly.
 
 The table below is the list of officially supported actions at this time:
 
@@ -26,5 +26,5 @@ Action | Description
 -------|------------
 session-add-right | Splits the terminal right
 session-add-down | Splits the terminal down
-app-new-window | Creates a new Tilix window
-app-new-session | Creates a new Tilix session
+app-new-window | Creates a new ttyx_ window
+app-new-session | Creates a new ttyx_ session

--- a/docs/manual/customlinks.md
+++ b/docs/manual/customlinks.md
@@ -5,7 +5,7 @@ nav_order: 7
 layout: default
 ---
 
-Tilix allows custom hyperlinks to be defined using regular expressions. These links can then be clicked on to launch an application passing information from the match to the application.
+ttyx_ allows custom hyperlinks to be defined using regular expressions. These links can then be clicked on to launch an application passing information from the match to the application.
 
 When configuring the application to be launched, the token ```$0``` can be used to represent the match obtained from the regular expression. If the regular expression includes groups then ```$1``` is the first group, ```$2``` the second group, etc.
 

--- a/docs/manual/margin.md
+++ b/docs/manual/margin.md
@@ -7,6 +7,6 @@ layout: default
 
 ![]({{site.baseurl}}/assets/images/manual/margin.png)
 
-Many code standards require line length always be under a prescribed limit to maintain readability. When using text editors like vi, emacs or nano it can be useful to have a margin indicating where this limit is. Tilix allows you to configure the limit on a per profile basis and then toggle the margin line on or off via a shortcut. The default shortcut is ctrl-alt-m.
+Many code standards require line length always be under a prescribed limit to maintain readability. When using text editors like vi, emacs or nano it can be useful to have a margin indicating where this limit is. ttyx_ allows you to configure the limit on a per profile basis and then toggle the margin line on or off via a shortcut. The default shortcut is ctrl-alt-m.
 
-This is available as of Tilix 1.8.1.
+This is available as of ttyx_ 1.8.1.

--- a/docs/manual/profileswitch.md
+++ b/docs/manual/profileswitch.md
@@ -7,7 +7,7 @@ layout: default
 
 #### Introduction
 
-Tilix supports automatically switching profiles based on certain conditions which is useful in a variety of situations such as when switching users, connecting to different hosts, changing to sensitive directories, etc. At the moment Tilix supports triggering a profile change based on the following:
+ttyx_ supports automatically switching profiles based on certain conditions which is useful in a variety of situations such as when switching users, connecting to different hosts, changing to sensitive directories, etc. At the moment ttyx_ supports triggering a profile change based on the following:
 
 * username
 * hostname
@@ -17,18 +17,18 @@ Note that when an automatic profile change is active, the menu to switch to diff
 
 #### Local Configuration
 
-Configuring profile switching in Tilix is done in the Advanced tab of the profile settings. Here you can configure the list of usernames, hostnames and directories that will trigger the profile change. The format used for the string is ```username@hostname:directory``` where either username, hostname or directory can be omitted but not all. Also at least one delimiter, either *@* or *:*, is also required to indicate which string is being represented.
+Configuring profile switching in ttyx_ is done in the Advanced tab of the profile settings. Here you can configure the list of usernames, hostnames and directories that will trigger the profile change. The format used for the string is ```username@hostname:directory``` where either username, hostname or directory can be omitted but not all. Also at least one delimiter, either *@* or *:*, is also required to indicate which string is being represented.
 
-**Note** that switching profiles based on username requires the use of a trigger to extract the username from the terminal output text. Triggers in turn require a patched VTE, see the [Triggers](https://gnunn1.github.io/tilix-web/manual/triggers/) page for more information.
+**Note** that switching profiles based on username requires the use of a trigger to extract the username from the terminal output text. Triggers in turn require a patched VTE, see the [Triggers]({{ site.baseurl }}/manual/triggers/) page for more information.
 
 #### Remote Configuration
 
 To enable profile changes when using SSH to connect to remote systems, the remote system must be configured to include an additional script or an appropriate trigger configured. 
 
-If you opt for the script, first scp the script ```/usr/share/tilix/scripts/tilix_int.sh``` from your local system where tilix is installed to the remote system. You will then need to source this script on the remote system, the easiest way to do this is to modify the .bashrc of the user you use to connect to include the script. For example, add the following to .bashrc:
+If you opt for the script, first scp the script ```/usr/share/ttyx/scripts/ttyx_int.sh``` from your local system where ttyx_ is installed to the remote system. You will then need to source this script on the remote system, the easiest way to do this is to modify the .bashrc of the user you use to connect to include the script. For example, add the following to .bashrc:
 
 {% highlight bash %}
-. ./tilix_int.sh
+. ./ttyx_int.sh
 {% endhighlight %}
 
 if you switch users on the remote system, you may need to source the script somewhere so it is available to all users.

--- a/docs/manual/quake.md
+++ b/docs/manual/quake.md
@@ -7,15 +7,15 @@ layout: default
 
 #### Introduction
 
-Tilix supports running in a _Quake_-style mode where it appears at the top of the screen and can be toggled on or off as needed. However, unlike other terminal emulators that support this mode Tilix does not register a global hot key. Instead you must register a hot key yourself with the Desktop Environment you are using, this is required because Wayland does not support global hot keys.
+ttyx_ supports running in a _Quake_-style mode where it appears at the top of the screen and can be toggled on or off as needed. However, unlike other terminal emulators that support this mode ttyx_ does not register a global hot key. Instead you must register a hot key yourself with the Desktop Environment you are using, this is required because Wayland does not support global hot keys.
 
 When you register the hot key, simply bind it to the following command:
 
 {% highlight bash %}
-tilix --quake
+ttyx --quake
 {% endhighlight %}
 
-When Tilix is run with the `--quake` switch, it will check if a quake style window is already running and if so simply toggle the window's visibility. If no quake style window has been created, then Tilix will create one and display it.
+When ttyx_ is run with the `--quake` switch, it will check if a quake style window is already running and if so simply toggle the window's visibility. If no quake style window has been created, then ttyx_ will create one and display it.
 
 Configuring this hot key for GNOME is quite simple, simply open the Keyboard settings and configure a hot key as per the example in the screenshot below:
 
@@ -25,9 +25,9 @@ Configuring this hot key for GNOME is quite simple, simply open the Keyboard set
 
 Note that quake mode in Wayland is currently not available, while initially supported it proved to be problematic given the limitations of the Wayland environment. Here are the options for enabling in Wayland:
 
-* Force the GDK back-end to be X11. You can force tilix to use X11 as the backend instead of Wayland by setting the quake command as ```GDK_BACKEND=x11 tilix --quake```. Note that you should also update the tilix desktop file to force the x11 backend as well.
+* Force the GDK back-end to be X11. You can force ttyx_ to use X11 as the backend instead of Wayland by setting the quake command as ```GDK_BACKEND=x11 ttyx --quake```. Note that you should also update the ttyx_ desktop file to force the x11 backend as well.
 * There is a gnome-shell [quake](https://github.com/repsac-by/gnome-shell-extension-quake-mode) extension that enables any application to run in quake mode.
 
 ### KDE
 
-If you have the issue where the tilix quake window does not receive focus, try disabling the feature "Focus stealing prevention" in KDE as per the comment [here](https://github.com/gnunn1/tilix/issues/895#issuecomment-385275324).
+If you have the issue where the quake window does not receive focus, try disabling the feature "Focus stealing prevention" in KDE (the linked comment was originally filed against upstream Tilix: [here](https://github.com/gnunn1/tilix/issues/895#issuecomment-385275324)).

--- a/docs/manual/themes.md
+++ b/docs/manual/themes.md
@@ -5,7 +5,7 @@ nav_order: 4
 layout: default
 ---
 
-Tilix supports themes for configuring the color scheme of the terminal, each theme is stored in a file. A theme file is a simple json file that specifies the color for each element as well as identifying whether certain colors should be used or defaulted. Here is an example of a theme file:
+ttyx_ supports themes for configuring the color scheme of the terminal, each theme is stored in a file. A theme file is a simple json file that specifies the color for each element as well as identifying whether certain colors should be used or defaulted. Here is an example of a theme file:
 
 {% highlight json %}
 {
@@ -43,6 +43,6 @@ Tilix supports themes for configuring the color scheme of the terminal, each the
 }
 {% endhighlight %}
 
-Themes are loaded from one of two places by Tilix. The first is ```/usr/share/tilix/schemes```, these are the themes that are shipped with Tilix. The second place that Tilix looks for theme files is in the user home directory, specifically ```~/.config/tilix/schemes```. Users can place any custom themes they want to use here.
+Themes are loaded from one of two places by ttyx_. The first is ```/usr/share/ttyx/schemes```, these are the themes that are shipped with ttyx_. The second place that ttyx_ looks for theme files is in the user home directory, specifically ```~/.config/ttyx/schemes```. Users can place any custom themes they want to use here.
 
-While Tilix only includes a small number of themes, additional themes can be easily downloaded and installed. For instance, there are a couple of GitHub repositories as [Tilix-Themes](https://github.com/storm119/Tilix-Themes) and [gogh-to-tilix](https://github.com/isacikgoz/gogh-to-tilix) which have various pre-built themes.
+While ttyx_ only includes a small number of themes, additional themes can be easily downloaded and installed. Community theme repositories originally built for Tilix use a compatible JSON format, for example [Tilix-Themes](https://github.com/storm119/Tilix-Themes) and [gogh-to-tilix](https://github.com/isacikgoz/gogh-to-tilix).

--- a/docs/manual/title.md
+++ b/docs/manual/title.md
@@ -5,7 +5,7 @@ nav_order: 1
 layout: default
 ---
 
-Tilix support using variables in the various titles and names it allows to be configured. This enables the title to better reflect the current state of the application, session or currently focused terminal. Variables are available within a particular scope and can always be used in higher scopes. For example, the ${title} is a terminal scope variable but can be used in session and application titles where it reflects the currently active terminal.
+ttyx_ support using variables in the various titles and names it allows to be configured. This enables the title to better reflect the current state of the application, session or currently focused terminal. Variables are available within a particular scope and can always be used in higher scopes. For example, the ${title} is a terminal scope variable but can be used in session and application titles where it reflects the currently active terminal.
 
 Variables can be used in the following locations:
 
@@ -41,7 +41,7 @@ The following additional variables are supported in all titles except terminal t
 
 Variable | Description
 -------|------------
-${appName} | The name of the application, i.e. Tilix
+${appName} | The name of the application, i.e. ttyx_
 ${sessionName} | The name of the session
 ${sessionCount} | The total number of sessions
 ${sessionNumber} | The number of the session, i.e. session 2 out of 4 active

--- a/docs/manual/triggers.md
+++ b/docs/manual/triggers.md
@@ -5,21 +5,21 @@ nav_order: 3
 layout: default
 ---
 
-*Note that trigger support requires that the GTK VTE widget be built with a tilix specific [patch](https://github.com/gnunn1/tilix/blob/master/experimental/vte/alternate-screen.patch), otherwise triggers are disabled. Arch users can access this functionality by installing the [vte3-tilix-git](https://aur.archlinux.org/packages/vte3-tilix-git) package.*
+*Historically, trigger support required a [Tilix-specific patch](https://github.com/gnunn1/tilix/blob/master/experimental/vte/alternate-screen.patch) on top of GTK VTE (Arch users installed the [vte3-tilix-git](https://aur.archlinux.org/packages/vte3-tilix-git) package). Recent VTE releases include the alternate-screen support needed for triggers to work without a custom patch.*
 
 #### Introduction
 
-Tilix supports the concept of triggers, these are regular expressions defined by the user that when matched against text output by the terminal trigger an action. A trigger consists of a regular expression, the action to execute and a parameter string. Depending on the action, the parameter may not be used at all, may be a single string or a semi-colon delimited list of variables.
+ttyx_ supports the concept of triggers, these are regular expressions defined by the user that when matched against text output by the terminal trigger an action. A trigger consists of a regular expression, the action to execute and a parameter string. Depending on the action, the parameter may not be used at all, may be a single string or a semi-colon delimited list of variables.
 
-The result of the regular expression can be referenced as tokens in the parameter, Tilix will substitute the tokens in the parameter prior to executing the action. The token $0 refers to the complete regular expression match. If groups were defined in the regular expression, the tokens $1, $2, $3, etc refer to the individual group captures.
+The result of the regular expression can be referenced as tokens in the parameter, ttyx_ will substitute the tokens in the parameter prior to executing the action. The token $0 refers to the complete regular expression match. If groups were defined in the regular expression, the tokens $1, $2, $3, etc refer to the individual group captures.
 
 #### Supported Actions
 
-The following actions are supported by Tilix:
+The following actions are supported by ttyx_:
 
 Action | Description
 -------|------------
-Update State | This action updates the state that Tilix maintains about the terminal in terms of things like what directory or hostname is currently active in the terminal. The variables *username*, *hostname* and *directory* can be used to update the state respectively, these represent . See further below for an example of how to use this.
+Update State | This action updates the state that ttyx_ maintains about the terminal in terms of things like what directory or hostname is currently active in the terminal. The variables *username*, *hostname* and *directory* can be used to update the state respectively, these represent . See further below for an example of how to use this.
 Execute Command | This action executes the command provided in the parameter field.
 Send Notification | Sends a notification to the desktop environment. Two variables are supported by this action, *title* and *body*.
 Update Title | Updates the terminal title using the parameter field, it sets the override title specified in Layout Options.
@@ -29,9 +29,9 @@ Insert Password | Shows the password manager to enable a password to be inserted
 
 #### Options
 
-Tilix has an option to limit the number of lines that are checked for triggers, this is intended to improve performance on slower hardware. Every time a change happens in the terminal, this is reported to Tilix as a block of text. This block might consist of just a single character when the user is typing, or it might consist of several thousand lines when outputting a large text file via cat.
+ttyx_ has an option to limit the number of lines that are checked for triggers, this is intended to improve performance on slower hardware. Every time a change happens in the terminal, this is reported to ttyx_ as a block of text. This block might consist of just a single character when the user is typing, or it might consist of several thousand lines when outputting a large text file via cat.
 
-In the later scenario, we may generally not be too interested in checking for triggers in all lines of text. When this option is active, Tilix will only check the lines changed from the end of the text. So for example, if a block of text consisting of 20,000 lines of text was received but the option limit was active at 256, only the last 256 lines would be checked.
+In the later scenario, we may generally not be too interested in checking for triggers in all lines of text. When this option is active, ttyx_ will only check the lines changed from the end of the text. So for example, if a block of text consisting of 20,000 lines of text was received but the option limit was active at 256, only the last 256 lines would be checked.
 
 #### Examples
 
@@ -43,11 +43,11 @@ Regular Expression | Action | Parameter | Description
 
 #### How It Works
 
-To get the most of out of this feature, it's important to understand how this works under the hood. As an overview, Tilix uses a GTK component called the VTE to perform the actual terminal emulation. When changes occur in the VTE, it triggers an event to notify Tilix but does not include any information about the change itself. In order to execute triggers, Tilix saves the current row and column reported by the VTE so that when the next change event happens only the delta is processed for triggers.
+To get the most of out of this feature, it's important to understand how this works under the hood. As an overview, ttyx_ uses a GTK component called the VTE to perform the actual terminal emulation. When changes occur in the VTE, it triggers an event to notify ttyx_ but does not include any information about the change itself. In order to execute triggers, ttyx_ saves the current row and column reported by the VTE so that when the next change event happens only the delta is processed for triggers.
 
-This means that any change in the terminal will be processed but the grouping of these changes is entirely up to the VTE. For example, when typing text Tilix will run triggers against each character entered by the user individually, it does not run triggers against the full command. 
+This means that any change in the terminal will be processed but the grouping of these changes is entirely up to the VTE. For example, when typing text ttyx_ will run triggers against each character entered by the user individually, it does not run triggers against the full command. 
 
-When outputting large amounts of text, i.e. cat'ing a large file, the VTE tends to report changes in very large chunks. This makes perfect sense the VTE needs to maintain a certain level of performance and caps the framerate by omitting rendering of text when it is not needed. As a result, when the scrollback buffer is limited (default in Tilix is 8192), not all of the text may be available to Tilix since it has already scrolled out of range of the buffer.
+When outputting large amounts of text, i.e. cat'ing a large file, the VTE tends to report changes in very large chunks. This makes perfect sense the VTE needs to maintain a certain level of performance and caps the framerate by omitting rendering of text when it is not needed. As a result, when the scrollback buffer is limited (default in ttyx_ is 8192), not all of the text may be available to ttyx_ since it has already scrolled out of range of the buffer.
 
-Thus if you want Tilix to process triggers for every line of text, you must set the scrollback buffer to unlimited and the trigger lines option to unlimited.
+Thus if you want ttyx_ to process triggers for every line of text, you must set the scrollback buffer to unlimited and the trigger lines option to unlimited.
 

--- a/docs/manual/vteconfig.md
+++ b/docs/manual/vteconfig.md
@@ -7,17 +7,17 @@ layout: default
 
 #### Background
 
-Tilix uses a GTK+ 3 widget called VTE (Virtual Terminal Emulator). The VTE widget was originally designed as the back-end for Gnome Terminal but was fortunately designed as a GTK widget so that other terminal emulator applications could leverage it instead of rolling their own. Many popular Linux terminal emulators use this component.
+ttyx_ uses a GTK+ 3 widget called VTE (Virtual Terminal Emulator). The VTE widget was originally designed as the back-end for Gnome Terminal but was fortunately designed as a GTK widget so that other terminal emulator applications could leverage it instead of rolling their own. Many popular Linux terminal emulators use this component.
 
 One aspect of VTE configuration is the use of /etc/profile.d/vte.sh. The VTE uses this script to override the PROMPT_COMMAND in order to feed itself additional information via terminal control codes. In particular, this script is used to tell the VTE the current directory of the shell. Previously the VTE component used to read this from /proc/&lt;pid&gt;/cwd however according to [VTE upstream](https://bugzilla.gnome.org/show_bug.cgi?id=697475) there were a number of issues with this approach and hence the change to /etc/profile.d/vte.sh.
 
-The issue with this change though is that different distributions treat /etc/profile.d differently. The expectation is that when a shell is initiated all scripts in /etc/profile.d are executed. On Fedora, this works as expected for both login and non-login based shells. However, other distributions (Ubuntu and Arch at least) only execute scripts in /etc/profile.d for login shells. The problem with this is the default configuration for most terminal emulators using VTE, including Gnome Terminal and Tilix, is to not run the shell as a login shell.
+The issue with this change though is that different distributions treat /etc/profile.d differently. The expectation is that when a shell is initiated all scripts in /etc/profile.d are executed. On Fedora, this works as expected for both login and non-login based shells. However, other distributions (Ubuntu and Arch at least) only execute scripts in /etc/profile.d for login shells. The problem with this is the default configuration for most terminal emulators using VTE, including Gnome Terminal and ttyx_, is to not run the shell as a login shell.
 
 #### Impact
 
 This means that on some Linux distributions vte.sh never gets executed and VTE loses certain features that are dependent on the PROMPT_COMMAND. In particular, the two features that we know are impacted:
 
-* The current directory is never reported by VTE. This means when splitting terminals in Tilix instead of inheriting the directory from the current terminal the split terminal always opens in your home terminal. Gnome Terminal has the same issue when creating new tabs
+* The current directory is never reported by VTE. This means when splitting terminals in ttyx_ instead of inheriting the directory from the current terminal the split terminal always opens in your home terminal. Gnome Terminal has the same issue when creating new tabs
 * The Fedora patched VTE that provides notification support depends on PROMPT_COMMAND, so this issue means notifications will not work.
 
 #### Fixing the issue
@@ -53,6 +53,6 @@ PROMPT_COMMAND=custom_prompt
 
 ##### 2. OR use a login shell
 
-Enable the option in your Tilix Profile (under Preferences) to use a login shell, the screenshot below shows the option that needs to be checked.
+Enable the option in your ttyx_ Profile (under Preferences) to use a login shell, the screenshot below shows the option that needs to be checked.
 
 ![Profile - Command](https://gnunn1.github.io/tilix-web/assets/images/manual/tilix_login_shell.png)


### PR DESCRIPTION
Stacks on top of #59. Content pass over the imported manual: product name, command name, dconf paths, install paths, and internal links now all say **ttyx_** instead of **Tilix**. Turns the docs from "Tilix docs we pretend are ours" into actual ttyx_ documentation.

## What changed

- **Product name**: `Tilix` → `ttyx_` in prose (word-boundary, not URLs)
- **Command name**: `tilix -a …`, `tilix --quake` → `ttyx -a …`, `ttyx --quake` in example commands
- **dconf path**: `/com/gexperts/Tilix/` → `/io/github/gwelr/ttyx/`
- **Install paths**: `/usr/share/tilix/` → `/usr/share/ttyx/`, `tilix_int.sh` → `ttyx_int.sh`
- **User config dir**: `~/.config/tilix/schemes` → `~/.config/ttyx/schemes`
- **Cross-page link**: `profileswitch.md` → Triggers link is now the relative site URL, not the upstream tilix-web URL

## Intentionally preserved as "Tilix"

- Attribution on the landing page to Gerald Nunn's Tilix manual
- Community theme repos (`storm119/Tilix-Themes`, `gogh-to-tilix`) — specific external repos, the names don't change when forked
- Historical note in `triggers.md` about the Tilix-specific VTE patch and the `vte3-tilix-git` AUR package — reworded as history, since modern VTE ships alternate-screen support without the custom patch
- KDE focus-stealing note in `quake.md`, framed as an upstream issue reference
- Screenshot URL in `vteconfig.md` still points to `gnunn1.github.io/tilix-web/assets/...` — illustrative image of the login-shell checkbox, which works identically in ttyx_. Replacing with a self-hosted ttyx_ capture is follow-up work.

## Out of scope (explicit follow-up)

- **Feature-accuracy review**: some notes (e.g. the VTE patch historical context) deserve verification against current ttyx_ behaviour. This PR only touches identifiers/names, not feature truth.
- **Screenshots**: all upstream images still point to tilix-web assets. Re-capture on ttyx_ and self-host under `docs/assets/` when branding lands.
- **ttyx_-specific features** not in the upstream manual: security section (paste protection, auto-clear, SSH indicator, scrollback protection), container support, etc. Needs a new page or two.

## Review tip

Diff is small (9 files, +38/-38). All the substitutions are line-level and easy to eyeball. The intentional retains I listed above are the only spots where "Tilix"/"tilix" still appears in the manual after this PR.

## Merging order

Base of this PR is `docs/publish-manual` (#59). Either:
- **Merge #59 first, then rebase this onto master** — cleanest history.
- **Merge this into #59's branch first, then merge the combined branch to master** — one final merge to master.

Happy to squash-merge this into #59 if you prefer a single PR; just say so.

Assisted by Claude Code.