### PR TITLE
docs: Suppress auto-generated child TOC on Manual page

### DIFF
--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -3,6 +3,7 @@ title: Manual
 layout: default
 nav_order: 2
 has_children: true
+has_toc: false
 permalink: /manual/
 ---
 


### PR DESCRIPTION
The Manual page showed two tables of contents stacked one after the other: the handcrafted **Contents** list with descriptive blurbs, and an auto-generated **TABLE OF CONTENTS** listing the page titles only.

The second comes from just-the-docs' default behaviour: when a parent page declares `has_children: true`, the theme appends a child-page list. Adding `has_toc: false` suppresses that addition while leaving the sidebar navigation intact (the sidebar still lists every manual page).

One-line change to `docs/manual/index.md` front matter.

## Test plan

- [ ] Merge
- [ ] Wait for Pages rebuild (~1-2 min)
- [ ] Visit https://gwelr.github.io/ttyx_/manual/ — only the handcrafted Contents list should appear above the footer
- [ ] Sidebar still lists all 10 manual pages

Assisted by Claude Code.