### PR TITLE
docs: Redesign landing page

### DIFF
--- a/docs/assets/images/logo.svg
+++ b/docs/assets/images/logo.svg
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="100"
+   height="100"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg12488"
+   sodipodi:docname="hey-ttyx.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs12492" />
+  <sodipodi:namedview
+     id="namedview12490"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="3.1996582"
+     inkscape:cx="64.69441"
+     inkscape:cy="41.09814"
+     inkscape:window-width="1904"
+     inkscape:window-height="1027"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g10308">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1939" />
+  </sodipodi:namedview>
+  <title
+     id="title12480">HeyNestor Logo</title>
+  <!-- Background: rounded square -->
+  <!-- N lettermark -->
+  <!-- Chat dot accent -->
+  <metadata
+     id="metadata306">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title>HeyNestor Logo</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g10308"
+     transform="matrix(1.0195333,0,0,1.0195333,99.894734,49.9376)"
+     style="stroke-width:0.980841">
+    <path
+       d="m -72.505445,23 c 0.01156,-15.454289 -0.02311,-30.909681 0.01733,-46.363281 0.120403,-2.152458 2.516037,-2.84397 4.32378,-2.636719 2.353186,0.07698 4.735985,-0.178362 7.065136,0.179688 2.817003,0.747392 3.807447,3.728738 5.359128,5.863596 5.744878,8.985572 11.489752,17.971144 17.234626,26.956716 0.01156,-10.120956 -0.02312,-20.243014 0.01733,-30.363281 0.120403,-2.152458 2.516037,-2.84397 4.32378,-2.636719 2.321119,0.08444 4.679849,-0.19225 6.971386,0.1875 2.212847,0.783458 1.595991,3.370779 1.6875,5.195655 -0.01156,14.659904 0.02311,29.320911 -0.01733,43.980126 -0.120403,2.152458 -2.516037,2.84397 -4.32378,2.636719 -2.353186,-0.07698 -4.735985,0.178362 -7.065136,-0.179688 -2.817003,-0.747392 -3.807447,-3.728738 -5.359128,-5.863596 C -48.015697,10.971144 -53.760571,1.985572 -59.505445,-7 c -0.01156,10.120956 0.02312,20.243014 -0.01733,30.363281 -0.120403,2.152458 -2.516037,2.84397 -4.32378,2.636719 -2.321119,-0.08444 -4.679849,0.19225 -6.971386,-0.1875 -1.224784,-0.344512 -1.734251,-1.64701 -1.6875,-2.8125 z"
+       fill="#ffffff"
+       id="path12484"
+       style="stroke-width:0.962049" />
+    <circle
+       cx="-19"
+       cy="-34"
+       r="8"
+       fill="#ffffff"
+       opacity="0.9"
+       id="circle12486"
+       style="stroke-width:0.962049" />
+    <rect
+       style="fill:#5e5c64;fill-opacity:1;stroke:#241f31;stroke-width:0.980841;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4380"
+       width="90.633461"
+       height="88.797318"
+       x="-94.701447"
+       y="-44.3158"
+       rx="7.2377672"
+       ry="8.2843323" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.96168;stroke-dasharray:none;stroke-opacity:1"
+       d="m -48.73347,-43.444946 c -0.188622,87.05348 -0.188622,87.05348 -0.188622,87.05348"
+       id="path1943" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:33.4265px;font-family:'Aller Light';-inkscape-font-specification:'Aller Light, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#f6f5f4;fill-opacity:1;stroke:#f6f5f4;stroke-width:1.96168;stroke-dasharray:none;stroke-opacity:1"
+       x="-70.831314"
+       y="-11.264954"
+       id="text2001"
+       transform="scale(1.1168773,0.89535349)"><tspan
+         sodipodi:role="line"
+         id="tspan1999"
+         x="-70.831314"
+         y="-11.264954"
+         style="fill:#f6f5f4;fill-opacity:1;stroke:#f6f5f4;stroke-width:1.96168;stroke-opacity:1">T</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-weight:bold;font-size:38.7221px;font-family:Georgia;-inkscape-font-specification:'Georgia, Bold';fill:#f6f5f4;fill-opacity:1;stroke:#f6f5f4;stroke-width:0.980841;stroke-dasharray:none;stroke-opacity:1"
+       x="-42.364964"
+       y="31.459837"
+       id="text2067"
+       transform="scale(0.99368345,1.0063567)"><tspan
+         sodipodi:role="line"
+         id="tspan2065"
+         x="-42.364964"
+         y="31.459837"
+         style="fill:#f6f5f4;fill-opacity:1;stroke:#f6f5f4;stroke-width:0.980841;stroke-dasharray:none;stroke-opacity:1">X</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.8709px;font-family:'Aller Light';-inkscape-font-specification:'Aller Light, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#f6f5f4;fill-opacity:1;stroke:#f6f5f4;stroke-width:1.96168;stroke-dasharray:none;stroke-opacity:1"
+       x="-31.800793"
+       y="-19.251936"
+       id="text2071"
+       transform="scale(1.17139,0.85368668)"><tspan
+         sodipodi:role="line"
+         id="tspan2069"
+         x="-31.800793"
+         y="-19.251936"
+         style="fill:#f6f5f4;fill-opacity:1;stroke:#f6f5f4;stroke-width:1.96168;stroke-opacity:1">T</tspan></text>
+    <path
+       id="path2109"
+       style="fill:none;stroke:#f6f5f4;stroke-width:3.43294;stroke-dasharray:none;stroke-opacity:1"
+       d="m -48.733482,-43.418102 -0.188622,32.437275 m 0.554995,2.0872551 42.9758193,0.188622"
+       sodipodi:nodetypes="cccc" />
+    <path
+       id="path2112"
+       style="fill:none;stroke:#f6f5f4;stroke-width:3.43294;stroke-dasharray:none;stroke-opacity:1"
+       d="m -48.733817,-43.088291 -0.187739,43.17564525 z m -43.268113,42.92135832 42.97501,0.18786871 z m 43.170412,0.003795 -0.172414,43.27242568 z" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:33.3803px;font-family:'Aller Light';-inkscape-font-specification:'Aller Light, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#f6f5f4;fill-opacity:1;stroke:#f6f5f4;stroke-width:1.96168;stroke-dasharray:none;stroke-opacity:1"
+       x="-72.051811"
+       y="36.563274"
+       id="text2071-9"
+       transform="scale(1.1184251,0.89411442)"><tspan
+         sodipodi:role="line"
+         id="tspan2069-3"
+         x="-72.051811"
+         y="36.563274"
+         style="fill:#f6f5f4;fill-opacity:1;stroke:#f6f5f4;stroke-width:1.96168;stroke-opacity:1">Y</tspan></text>
+    <path
+       id="rect974"
+       style="fill:#241f31;fill-opacity:1;stroke:#241f31;stroke-width:1.96168;stroke-dasharray:none;stroke-opacity:1"
+       d="m -15.771484,-43.990234 c -23.270521,-0.01633 -46.542251,-0.02457 -69.812732,0.0115 -3.902606,0.194511 -7.339455,3.661454 -7.388847,7.592542 -0.07881,2.489012 0.01426,4.981404 -0.02708,7.472133 0.01071,21.8735704 -0.03029,43.748175 0.02944,65.621094 0.258514,3.853687 3.696091,7.216557 7.584508,7.266032 2.489011,0.07881 4.981404,-0.01426 7.472132,0.02708 21.87357,-0.01071 43.748176,0.03029 65.621094,-0.02944 3.853687,-0.258513 7.216557,-3.696091 7.266032,-7.584507 0.07881,-2.489012 -0.01426,-4.981404 0.02708,-7.472133 -0.01071,-21.8735696 0.03029,-43.748175 -0.02944,-65.621094 -0.258513,-3.853686 -3.696091,-7.216557 -7.584507,-7.266031 -1.051426,-0.07473 -2.10505,-0.03068 -3.15768,-0.01717 z M -85,-48 h 72 c 6.648,0 12,5.352 12,12 v 72 c 0,6.648 -5.352,12 -12,12 h -72 c -6.648,0 -12,-5.352 -12,-12 v -72 c 0,-6.648 5.352,-12 12,-12 z" />
+  </g>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,35 +2,60 @@
 title: Home
 layout: home
 nav_order: 1
+description: "Documentation for ttyx_, a tiling terminal emulator for Linux."
+permalink: /
 ---
 
+<p style="text-align: center; margin-top: 1.5rem;">
+  <img src="{{ site.baseurl }}/assets/images/logo.svg" alt="ttyx_ logo" width="120">
+</p>
+
 # ttyx_
+{: .fs-9 .text-center }
 
-**Tilix, but with a pulse.**
+Tilix, but with a pulse.
+{: .fs-6 .fw-300 .text-center }
 
-ttyx_ is an actively maintained fork of [Tilix](https://github.com/gnunn1/tilix), the tiling terminal emulator for Linux. The original project did amazing work but, with development stalled and a growing list of unaddressed bugs, ttyx_ picks up where it left off.
+ttyx_ is an actively maintained fork of [Tilix](https://github.com/gnunn1/tilix), the tiling terminal emulator for Linux. The original project did amazing work but, with development stalled and a growing list of unaddressed bugs, ttyx_ picks up where it left off — with a focus on security hardening and responsiveness to modern Linux desktops.
+{: .text-center }
 
-## Getting started
+<div style="text-align: center; margin: 2rem 0;">
+  <a href="https://github.com/gwelr/ttyx_#building" class="btn btn-primary fs-5 mr-2">Install</a>
+  <a href="{{ site.baseurl }}/manual/" class="btn fs-5 mr-2">Read the manual</a>
+  <a href="https://github.com/gwelr/ttyx_" class="btn fs-5">View on GitHub</a>
+</div>
 
-- [Download & install](https://github.com/gwelr/ttyx_#building)
-- [What's new in ttyx_ since Tilix](https://github.com/gwelr/ttyx_#whats-new-since-tilix)
-- [Report an issue](https://github.com/gwelr/ttyx_/issues)
+---
 
-## Documentation
+## What you get
 
-The [Manual]({{ site.baseurl }}/manual/) covers the main feature areas:
+### Tile terminals any way you like
 
-- **Titles & variables** — customize window, session, and terminal titles with runtime variables
-- **Quake mode** — drop-down terminal activated by a global hot key
-- **Triggers** — react to terminal output with regex-driven actions
-- **Color schemes & themes** — switch and author color schemes
-- **Badges** — overlay status information on a terminal
-- **Profile switching** — swap profiles based on hostname or working directory
-- **Custom links** — make your own clickable patterns in terminal output
-- **Margin indicators** — visual markers at column positions
-- **VTE configuration** — low-level terminal emulator tuning
-- **CLI actions** — invoke ttyx_ actions from the command line
+Split horizontally, vertically, nest arbitrarily. Drag and drop terminals within and between windows. Save and restore layouts as sessions. Synchronize input across terminals when you need to drive several at once. Everything that made Tilix the tiling terminal of choice on Linux is still here.
+
+### Security-conscious by default
+
+Paste from the clipboard with review dialogs, dangerous-command detection, and auto-clear after copy. Clear visual indicators when a session is running as root or over SSH. Core-dump protection, in-memory-only scrollback, and a one-shortcut `Secure Clear` for wiping the scrollback when sensitive data has been displayed.
+
+A dedicated **Security features** page is coming; until then the [project README](https://github.com/gwelr/ttyx_#security-features) has the full list.
+
+### Actively maintained
+
+ttyx_ ships bug fixes (crash on malformed OSC 7 URIs, preferences-dialog segfaults, proxy URL construction, focus stealing on terminal restart, …), new color schemes, release-build optimizations, and a growing test suite. Contributions welcome via pull request; the issue tracker is actually read.
+
+A **What's new vs Tilix** page is in progress; the README has the [full change list](https://github.com/gwelr/ttyx_#whats-new-since-tilix) in the meantime.
+
+---
+
+## Where to next
+
+- [**Installation**](https://github.com/gwelr/ttyx_#building) — Debian/Ubuntu dependencies, Meson and Dub build options.
+- [**Manual**]({{ site.baseurl }}/manual/) — topic-by-topic reference: titles, Quake mode, triggers, color schemes, profile switching, and more.
+- [**Migrating from Tilix**](https://github.com/gwelr/ttyx_#migrating-from-tilix) — what ttyx_ does with your existing Tilix config on first run.
+- [**Report an issue**](https://github.com/gwelr/ttyx_/issues) — bug reports and feature requests.
+
+---
 
 ## About this documentation
 
-Much of the manual content originated in Gerald Nunn's [Tilix](https://github.com/gnunn1/tilix) and is reused under [MPL-2.0](https://github.com/gwelr/ttyx_/blob/master/LICENSE). Some pages still reference "Tilix" where the wording hasn't been updated yet — corrections welcome via pull request.
+Much of the manual content originated in Gerald Nunn's [Tilix](https://github.com/gnunn1/tilix) and is reused under [MPL-2.0](https://github.com/gwelr/ttyx_/blob/master/LICENSE). Adaptation is in progress; see the [documentation tracking issue](https://github.com/gwelr/ttyx_/issues/62) for what's done and what's still open.


### PR DESCRIPTION
Refs #62. Second PR in the Tier B documentation pass.

## What changes

Replaces the placeholder landing page (two bullet lists, one tagline) with a proper hero structure:

- Logo (copied from `data/hey-ttyx.svg` into `docs/assets/images/logo.svg`)
- Title at `fs-9`, tagline at `fs-6`, one-sentence fork rationale
- Three CTA buttons: **Install**, **Read the manual**, **View on GitHub**
- Three feature blocks, each one sentence of positioning + one paragraph:
  1. **Tile terminals any way you like** — the original Tilix value prop
  2. **Security-conscious by default** — ttyx_'s differentiator
  3. **Actively maintained** — the fork rationale
- "Where to next" link block
- Attribution footer unchanged

## Gaps the page flags honestly

The Security and "What's new vs Tilix" sections each reference dedicated pages that don't exist yet — those are PRs 3 and 5 in the Tier B plan. Rather than ship placeholder links, the landing page explicitly notes "coming" and links to the relevant README sections in the meantime so visitors aren't left empty-handed.

## Preview locally

If you have Jekyll installed:
```
cd docs && bundle exec jekyll serve
```

Otherwise, merge and wait ~1–2 min for GitHub Pages to rebuild.

## Test plan

- [ ] Merge
- [ ] Wait for Pages rebuild
- [ ] Visit https://gwelr.github.io/ttyx_/ — verify logo renders, CTA buttons work, feature sections layout cleanly
- [ ] Verify the "Install" button goes to README's #building anchor
- [ ] Verify the "Read the manual" button lands on the manual index page

Assisted by Claude Code.