### PR TITLE
docs: Add CHANGELOG.md, What's new vs Tilix, Changelog landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,102 @@
+# Changelog
+
+All notable changes to **ttyx_** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Documentation site at <https://gwelr.github.io/ttyx_/> — built with Jekyll + just-the-docs, manual content adapted from upstream Tilix under MPL-2.0 (#59, #60, #61, #63, #64).
+- Unit test coverage for the password manager row-removal path, extracted as `removeRowById` (#54).
+- Unit tests for the proxy URL builder, sensitive-value redaction, and process introspection helpers (#55, #56, #58).
+
+### Changed
+- Extracted pure helpers out of the terminal widget module to reduce complexity and unlock testing: `pointInTriangle` → `gx.util.geometry`, `parsePairs` → `gx.util.string`, process introspection → `gx.util.proc` (#57, #58).
+- Process root detection now goes through a single `readProcStatus` helper; the `/proc/[pid]/status` parser was previously duplicated across `monitor.d` and `activeprocess.d` (#58).
+- Debug log path resolution now prefers `$XDG_RUNTIME_DIR/ttyx.log` over `/tmp/ttyx.log` when file logging is enabled (#55).
+
+### Fixed
+- **Password manager delete silently failed** — the delete button claimed success even when the keyring operation failed, and legacy-schema entries from the Tilix migration couldn't be deleted at all (#50, #54).
+- **Proxy URL malformed** — the generated `http_proxy` URL had a redundant leading `@` before userinfo, which strict RFC-3986 parsers reject; credentials were also not percent-encoded, so passwords containing `@`, `:`, `/` broke the URL entirely (#51, #55).
+- **`https_proxy` missing authentication** — the auth block was gated on `scheme == "http"` so the HTTPS proxy never received credentials even when configured (#51, #55).
+- **Debian Testing CI build** — GtkD bindings were removed from Debian Testing's apt archive; CI now builds GtkD from source on that image (#49).
+
+### Security
+- **Config migration hardened against symlink attacks** — `migrateConfigBetween` now refuses to follow symlinks and skips existing target files during the Tilix → ttyx_ first-run migration (#49).
+- **Sensitive values redacted in trace logs** — environment variables whose keys contain `password`/`token`/`secret`/`auth` are replaced with `[redacted]`; proxy URLs have their userinfo stripped before logging (#51, #55, #56).
+- **Command-line arguments and hyperlink traces redacted** — URL userinfo is stripped from argv and from terminal hyperlink click events before they reach any log sink (#56).
+
+## [1.1.1] — 2026-04-18
+
+Maintenance release focused on identity: ttyx_ became its own project, with automatic migration for users coming from Tilix.
+
+### Added
+- **Automatic migration from Tilix on first run**: `~/.config/tilix/` is copied to `~/.config/ttyx/` (original kept as backup); libsecret entries stored under the old Tilix schema are still read and new passwords are written to the ttyx schema; both `TTYX_ID` and `TILIX_ID` are set in shells so existing shell integrations keep working.
+- New "Migrating from Tilix" section in README.
+- New "Troubleshooting" section covering stale icon caches and Wayland Quake-mode limitations.
+- `ROADMAP.md` documenting vision and phase plan.
+
+### Changed
+- Renamed user-visible Tilix references in the Nautilus menu, shortcuts window, GSettings descriptions, icon filenames, and log/temp paths.
+- Rewrote the man page under ttyx_ identity.
+- Dropped 30 stale translation files that still carried Tilix-branded source strings.
+- Release process simplified: ship only the Flatpak bundle with signed checksums. The hand-assembled binary tarball was dropped — distro packagers should build from source, Flatpak covers direct users.
+
+### Fixed
+- Color scheme list no longer shows duplicates when the same scheme exists in both user config and system data dirs (user config wins).
+- Post-install script writes a minimal `index.theme` at the install prefix so `gtk-update-icon-cache` can generate a valid icon cache.
+- AppStream metadata no longer includes stale Tilix release entries.
+
+## [1.1.0] — 2026-04-15
+
+A major security and performance release. ttyx_ positioned itself as a security-conscious tiling terminal emulator for Linux.
+
+### Added
+- **Paste protection** — bracketed-paste escape stripping (blocks `ESC[200~` / `ESC[201~` injection), multi-line paste review dialog, dangerous-command detection (`sudo`, `su`, `rm -rf`, `curl | bash`, `dd if=`, `mkfs`, `chmod 777`, fork bombs), per-paste warnings that appear every time rather than once per session.
+- **Clipboard auto-clear** — clears clipboard after a configurable 5–300 s timeout to prevent sensitive data from lingering.
+- **SSH session indicator** — blue tint and label when connected via ssh, scp, sftp, mosh, or sshfs.
+- **Root indicator** — red tint and label when running with elevated privileges.
+- **Core-dump protection** — `prctl(PR_SET_DUMPABLE, 0)` blocks `/proc/pid/mem` reads and core-dump generation; toggleable for debugging.
+- **In-memory-only scrollback** — removed the unlimited scrollback option; capped at 256–999,999 lines, never written to disk.
+- **Secure Clear** (`Ctrl+Shift+L`) — on-demand wipe of the scrollback buffer.
+- 119 unit tests covering security, clipboard, rendering, and process-monitor modules.
+- Security options consolidated under **Preferences → Advanced → Security** with descriptive labels.
+
+### Changed
+- **ProcessMonitor optimization** — idle CPU reduced from 1.4% to 0.1% by replacing full `/proc` scans with targeted foreground-process lookups.
+- **Major terminal.d decomposition** — `terminal.d` (178 KB) had `ClipboardHandler`, `TerminalRenderer`, `ProcessQuery`, `SpawnHandler`, `FlatpakHostCommands` extracted.
+- PreferenceRegistry pattern replaced the switch-based preference dispatch.
+
+### Fixed
+- GC crash when opening preferences on GLib 2.84+ (Flatpak environments).
+- SSH and root indicators not clearing when the foreground process exits.
+- Color scheme test when schemes are not installed in XDG paths.
+
+## [1.0.2] — 2026-04-07
+
+First release under the ttyx_ name.
+
+### Added
+- New tabs open next to the current tab (not at the end).
+- Option to strip trailing whitespace on copy.
+- Visual indicator when terminal is running as root.
+- `~` and `@` added to default word-select characters.
+- 8 new built-in color schemes: Catppuccin (Latte, Mocha), Dracula, Gruvbox (Dark, Light), Nord, One Dark, Tokyo Night.
+- Comprehensive unit test suite across utility and core modules.
+
+### Changed
+- Release build optimizations: proper `-O3`, `-release`, `-inline`, `-boundscheck=off` flags for both meson and dub. Binary size dropped from 17 MB (debug) to 3.3 MB (release, stripped).
+
+### Fixed
+- Crash on malformed URIs in OSC 7 and drag-and-drop.
+- Color schemes with `use-theme-colors` incorrectly shown as "Custom".
+- Title bar markup rendering (`setText` instead of `setMarkup`).
+- Focus stealing on terminal restart.
+- Proxy host protocol prefix duplication.
+- Empty clipboard text after stripping whitespace.
+- Preferences dialog segfaults when changing profiles or closing the dialog.
+
+## Attribution
+
+ttyx_ is a fork of [Tilix](https://github.com/gnunn1/tilix) by Gerald Nunn, licensed under [MPL-2.0](LICENSE). Release history before 1.0.2 is part of the upstream Tilix project.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,24 @@
+---
+title: Changelog
+layout: default
+nav_order: 4
+permalink: /changelog/
+---
+
+# Changelog
+
+Version-by-version release notes live in [CHANGELOG.md](https://github.com/gwelr/ttyx_/blob/master/CHANGELOG.md) at the repository root, in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. The canonical copy is the file at the root so that downstream packagers and tooling (Debian, Flatpak, GitHub release UI) all see the same content.
+
+## Quick links
+
+- [Full changelog on GitHub](https://github.com/gwelr/ttyx_/blob/master/CHANGELOG.md) — all releases, Keep-a-Changelog format.
+- [GitHub Releases page](https://github.com/gwelr/ttyx_/releases) — per-tag release notes with downloadable Flatpak bundles and signed checksums.
+- [What's new vs Tilix]({{ site.baseurl }}/whats-new/) — feature-level comparison with upstream Tilix, not version-by-version.
+
+## Release cadence
+
+ttyx_ is a freetime project and releases are irregular. See the [GitHub Releases](https://github.com/gwelr/ttyx_/releases) page for the latest tagged build. In-progress work is in the `[Unreleased]` section of the changelog.
+
+## Reporting issues
+
+Bug reports belong in the [issue tracker](https://github.com/gwelr/ttyx_/issues). See the README's [Contributing](https://github.com/gwelr/ttyx_#contributing) section for what a complete bug report should include.

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ A dedicated **Security features** page is coming; until then the [project README
 
 ttyx_ ships bug fixes (crash on malformed OSC 7 URIs, preferences-dialog segfaults, proxy URL construction, focus stealing on terminal restart, …), new color schemes, release-build optimizations, and a growing test suite. Contributions welcome via pull request; the issue tracker is actually read.
 
-A **What's new vs Tilix** page is in progress; the README has the [full change list](https://github.com/gwelr/ttyx_#whats-new-since-tilix) in the meantime.
+See [**What's new vs Tilix**]({{ site.baseurl }}/whats-new/) for the full comparison and the [**changelog**]({{ site.baseurl }}/changelog/) for per-release notes.
 
 ---
 
@@ -51,6 +51,8 @@ A **What's new vs Tilix** page is in progress; the README has the [full change l
 
 - [**Installation**](https://github.com/gwelr/ttyx_#building) — Debian/Ubuntu dependencies, Meson and Dub build options.
 - [**Manual**]({{ site.baseurl }}/manual/) — topic-by-topic reference: titles, Quake mode, triggers, color schemes, profile switching, and more.
+- [**What's new vs Tilix**]({{ site.baseurl }}/whats-new/) — feature-level differences from upstream.
+- [**Changelog**]({{ site.baseurl }}/changelog/) — per-release notes.
 - [**Migrating from Tilix**](https://github.com/gwelr/ttyx_#migrating-from-tilix) — what ttyx_ does with your existing Tilix config on first run.
 - [**Report an issue**](https://github.com/gwelr/ttyx_/issues) — bug reports and feature requests.
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,0 +1,89 @@
+---
+title: What's new vs Tilix
+layout: default
+nav_order: 3
+permalink: /whats-new/
+---
+
+# What's new in ttyx_ vs Tilix
+
+ttyx_ is a fork of [Tilix](https://github.com/gnunn1/tilix) that picks up where upstream development stalled. This page summarizes what has changed: new features, security hardening, bug fixes, and infrastructure work.
+
+For version-by-version release notes, see the [changelog]({{ site.baseurl }}/changelog/).
+
+## Security hardening
+
+The headline difference. ttyx_ adds a **Preferences → Advanced → Security** panel and ships the following protections; none of them exist in upstream Tilix.
+
+### Paste protection
+
+- **Bracketed paste escape stripping** silently removes `ESC[200~` / `ESC[201~` sequences that could break out of the shell's paste-mode and inject commands. Always active, no option to disable.
+- **Multi-line paste review** shows a review dialog before pasting multi-line content, so you can inspect and edit before the text reaches the shell. Default: on.
+- **Dangerous command detection** flags pastes containing `sudo`, `su`, `rm -rf`, `curl | bash`, `dd if=`, `mkfs`, `chmod 777`, fork bombs, and similar patterns.
+- **Per-paste warnings** — the unsafe-paste warning now appears every time, not just once per session.
+
+### Clipboard protection
+
+- **Clipboard auto-clear** — automatically clears the clipboard after a configurable 5–300 s timeout following a copy from the terminal, preventing sensitive data like passwords and tokens from lingering. Only clears if the clipboard still holds the content you copied. Default: off, 30 s.
+
+### Visual indicators
+
+- **Root indicator** — red tint and "as root" label when any process in the terminal is running with elevated privileges.
+- **SSH indicator** — blue tint and "ssh" label when connected via ssh, scp, sftp, mosh, or sshfs.
+
+### Memory protection
+
+- **Core dump protection** — the process is marked non-dumpable via `prctl(PR_SET_DUMPABLE, 0)`, blocking `/proc/pid/mem` reads and core-dump generation. Disable from preferences if you need to attach GDB.
+- **In-memory-only scrollback** — the unlimited scrollback option was removed; the scrollback is capped at 256–999,999 lines and kept entirely in memory. VTE never writes history to disk.
+- **Secure Clear** (`Ctrl+Shift+L`) — on-demand wipe of the scrollback buffer, available in the hamburger menu and the right-click context menu.
+
+### Logging hygiene
+
+- Sensitive environment variables (proxy URLs, tokens, passwords, secrets) are redacted before being written to trace logs.
+- Command-line arguments and clicked-hyperlink traces have their URL userinfo stripped before logging.
+- When file logging is enabled, the log file is written to `$XDG_RUNTIME_DIR/ttyx.log` (mode 0700 by systemd convention) instead of world-readable `/tmp/ttyx.log`.
+
+## Fixed bugs carried over from upstream
+
+Upstream Tilix development stalled with known issues unresolved. ttyx_ ships fixes for:
+
+- **Crash on malformed OSC 7 URIs** and drag-and-drop payloads.
+- **Color schemes incorrectly shown as "Custom"** when `use-theme-colors` was enabled.
+- **Title bar markup rendering** using `setText` instead of `setMarkup`.
+- **Focus stealing on terminal restart.**
+- **Proxy host protocol prefix duplication** in generated env vars.
+- **Preferences dialog segfaults** when changing profiles or closing the dialog, including a GC-interaction crash on GLib 2.84+ (Flatpak).
+- **Empty clipboard after whitespace stripping.**
+- **Root/SSH indicators not clearing** when the foreground process exits.
+- **Password-manager delete** silently failing for legacy-schema entries and claiming success even when the keyring operation failed.
+- **Malformed proxy URL** with a redundant leading `@`, plus unencoded credentials that broke the URL if they contained `@`, `:`, or `/`.
+- **`https_proxy` never received authentication credentials** even when configured.
+- **Symlink-attack susceptibility** during the Tilix → ttyx_ config migration.
+
+## New features and quality-of-life improvements
+
+- **New tabs open next to the current tab** (not at the end).
+- **Strip trailing whitespace on copy** — optional toggle.
+- **`~` and `@` added to default word-select characters** — double-click selects full paths and email-like tokens.
+- **8 new color schemes** ship in-box: Catppuccin (Latte, Mocha), Dracula, Gruvbox (Dark, Light), Nord, One Dark, Tokyo Night.
+
+## Performance
+
+- **ProcessMonitor optimization** cut idle CPU from 1.4% to 0.1% by replacing full `/proc` scans with targeted foreground-process lookups.
+- **Release build optimizations** — proper `-O3`, `-release`, `-inline`, `-boundscheck=off` flags for both Meson and Dub; binary size dropped from 17 MB (debug) to 3.3 MB (release, stripped).
+
+## Infrastructure
+
+- **Unit test suite** — from zero to more than 119 tests covering security, clipboard, rendering, process monitoring, and the extracted utility modules. Test count continues to grow with each refactor.
+- **Major `terminal.d` decomposition** — `ClipboardHandler`, `TerminalRenderer`, `ProcessQuery`, `SpawnHandler`, `FlatpakHostCommands`, and geometry / string / proc helpers were extracted from what was originally a 178 KB monolithic widget file.
+- **PreferenceRegistry pattern** replaces the switch-based preference dispatch.
+- **CI coverage** across Debian Stable, Debian Testing, and Ubuntu LTS via Podman containers, plus Dub builds with both DMD and LDC.
+
+## Identity and migration
+
+- ttyx_ uses its own schema identifier (`io.github.gwelr.ttyx`) for GSettings.
+- libsecret entries use `io.github.gwelr.ttyx.Password`; legacy entries stored under `com.gexperts.tilix.Password` are still read on first run.
+- Shells inside terminals get both `TTYX_ID` and `TILIX_ID` set, so existing shell-integration scripts continue to work.
+- On first run, `~/.config/tilix/` is copied to `~/.config/ttyx/`; the original is left in place as a backup.
+
+See [Migrating from Tilix](https://github.com/gwelr/ttyx_#migrating-from-tilix) for the full migration checklist.


### PR DESCRIPTION
Refs #62. Third PR in the Tier B documentation pass.

## What's in

**`CHANGELOG.md` at the repo root** — Keep-a-Changelog format, backfilled from:
- [v1.0.2 release notes](https://github.com/gwelr/ttyx_/releases/tag/v1.0.2) (first release under the ttyx_ name)
- [v1.1.0 release notes](https://github.com/gwelr/ttyx_/releases/tag/v1.1.0) (security hardening release)
- [v1.1.1 release notes](https://github.com/gwelr/ttyx_/releases/tag/v1.1.1) (identity + migration)
- Everything merged since v1.1.1 (config migration hardening, password delete fix, proxy URL fix, log redaction, refactors, docs work) goes under `[Unreleased]`.

**`docs/whats-new.md` at `/whats-new/`** — feature-level comparison with upstream Tilix. Expanded from the README's "What's new since Tilix" section, split into:
- Security hardening (paste / clipboard / indicators / memory / logging)
- Fixed bugs carried over from upstream
- New features and quality-of-life improvements
- Performance
- Infrastructure
- Identity and migration

**`docs/changelog.md` at `/changelog/`** — brief landing page that links out to the canonical `CHANGELOG.md` on GitHub. Chosen over inlining the full changelog content to keep a single source of truth at the repo root.

**`docs/index.md`** — the "Actively maintained" feature block and the "Where to next" list now link to both new pages.

## Design decision: single source of truth

`CHANGELOG.md` at the root is what distro packagers, Flatpak tooling, and the GitHub release UI all reference. The docs page deliberately doesn't duplicate the content — it introduces the concept and links out. The maintenance alternative (two files to keep in sync per release) wasn't worth it for what's a once-per-release update.

## Test plan

- [ ] Merge
- [ ] Wait for Pages rebuild
- [ ] Visit `https://gwelr.github.io/ttyx_/whats-new/` — renders cleanly with all sections
- [ ] Visit `https://gwelr.github.io/ttyx_/changelog/` — links to CHANGELOG.md on GitHub resolve
- [ ] Visit `https://gwelr.github.io/ttyx_/` — the two new pages appear in the "Where to next" block
- [ ] Sidebar nav includes both new pages at their `nav_order` positions

Assisted by Claude Code.