### PR TITLE
docs: Add Install and Migrating pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ ttyx_ is an actively maintained fork of [Tilix](https://github.com/gnunn1/tilix)
 {: .text-center }
 
 <div style="text-align: center; margin: 2rem 0;">
-  <a href="https://github.com/gwelr/ttyx_#building" class="btn btn-primary fs-5 mr-2">Install</a>
+  <a href="{{ site.baseurl }}/install/" class="btn btn-primary fs-5 mr-2">Install</a>
   <a href="{{ site.baseurl }}/manual/" class="btn fs-5 mr-2">Read the manual</a>
   <a href="https://github.com/gwelr/ttyx_" class="btn fs-5">View on GitHub</a>
 </div>
@@ -49,11 +49,11 @@ See [**What's new vs Tilix**]({{ site.baseurl }}/whats-new/) for the full compar
 
 ## Where to next
 
-- [**Installation**](https://github.com/gwelr/ttyx_#building) — Debian/Ubuntu dependencies, Meson and Dub build options.
+- [**Install**]({{ site.baseurl }}/install/) — Flatpak (recommended) and source builds (Meson / Dub).
 - [**Manual**]({{ site.baseurl }}/manual/) — topic-by-topic reference: titles, Quake mode, triggers, color schemes, profile switching, and more.
 - [**What's new vs Tilix**]({{ site.baseurl }}/whats-new/) — feature-level differences from upstream.
 - [**Changelog**]({{ site.baseurl }}/changelog/) — per-release notes.
-- [**Migrating from Tilix**](https://github.com/gwelr/ttyx_#migrating-from-tilix) — what ttyx_ does with your existing Tilix config on first run.
+- [**Migrating from Tilix**]({{ site.baseurl }}/migrating/) — what ttyx_ does with your existing Tilix config on first run.
 - [**Report an issue**](https://github.com/gwelr/ttyx_/issues) — bug reports and feature requests.
 
 ---

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,128 @@
+---
+title: Install
+layout: default
+nav_order: 2
+permalink: /install/
+---
+
+# Install
+
+Two install paths depending on who you are:
+
+| If you are… | Use this |
+|--------------|------------|
+| An end user who wants to run ttyx_ | [Flatpak](#flatpak-recommended) — signed bundle with checksum verification |
+| A distro packager, or a developer building from source | [Source build](#source-build) via Meson or Dub |
+
+---
+
+## Flatpak (recommended)
+
+Flatpak is the supported direct-user distribution channel. Each release ships a signed `.flatpak` bundle and a detached GPG signature over the SHA-256 checksums, so you can verify integrity end-to-end.
+
+### 1. Download the latest release
+
+Grab `ttyx-<version>_x86_64.flatpak` and `ttyx-<version>_SHA256SUMS.asc` from the [latest release](https://github.com/gwelr/ttyx_/releases/latest).
+
+### 2. Verify the bundle
+
+```bash
+# Verify the signature on the checksum file
+gpg --verify ttyx-<version>_SHA256SUMS.asc
+
+# Verify the bundle's checksum matches
+sha256sum -c ttyx-<version>_SHA256SUMS.asc 2>/dev/null
+```
+
+Both commands must exit with success before installing.
+
+### 3. Install
+
+```bash
+flatpak install --user ttyx-<version>_x86_64.flatpak
+```
+
+### 4. Run
+
+Launch from your desktop environment's application menu, or run:
+
+```bash
+flatpak run io.github.gwelr.ttyx
+```
+
+---
+
+## Source build
+
+For distro packagers, Flatpak maintainers, or developers.
+
+### Requirements
+
+- GTK 3.18+
+- VTE 0.46+ (0.76+ recommended — some features like triggers depend on newer VTE releases)
+- dconf / GSettings
+- A D compiler (LDC recommended for release builds, DMD also supported)
+
+### With Meson (primary, used in CI)
+
+The Meson build resolves the GtkD bindings (`gtkd-3`, `vted-3`) via pkg-config, so those must be installed separately. On distros that still package them, apt covers everything. **Debian Testing / Sid** dropped GtkD from their archive — on those you have to build GtkD from source.
+
+**Debian Stable / Ubuntu:**
+
+```bash
+sudo apt-get install libgtk-3-dev libvte-2.91-dev libatk1.0-dev \
+  libcairo2-dev libpango1.0-dev librsvg2-dev libglib2.0-dev \
+  libsecret-1-dev libgtksourceview-3.0-dev libpeas-dev dh-dlang \
+  libgtkd-3-dev libvted-3-dev
+```
+
+**Debian Testing / Sid** (no `libgtkd-3-dev` / `libvted-3-dev` in archive):
+
+```bash
+sudo apt-get install libgtk-3-dev libvte-2.91-dev libatk1.0-dev \
+  libcairo2-dev libpango1.0-dev librsvg2-dev libglib2.0-dev \
+  libsecret-1-dev libgtksourceview-3.0-dev libpeas-dev dh-dlang
+```
+
+Then build and install GtkD v3.x from source. The CI helper at [.github/ci/make-install-deps-extern.sh](https://github.com/gwelr/ttyx_/blob/master/.github/ci/make-install-deps-extern.sh) has the exact commands.
+
+**Build, install, test:**
+
+```bash
+meson setup builddir --buildtype=release
+ninja -C builddir
+sudo ninja -C builddir install
+
+# Optional: run the unit test suite
+meson test -C builddir --print-errorlogs
+```
+
+### With Dub
+
+Simpler for development, doesn't need GtkD installed system-wide (Dub pulls the bindings from the registry).
+
+```bash
+dub build --build=release --compiler=ldc2
+
+# or with DMD:
+dub build --build=release --compiler=dmd
+
+# Unit tests:
+dub test --compiler=ldc2
+```
+
+---
+
+## First launch
+
+On first run:
+
+- If you previously used Tilix, ttyx_ [automatically migrates]({{ site.baseurl }}/migrating/) your session files and reads existing saved passwords.
+- The terminal opens with the default profile. Preferences live under **Hamburger menu → Preferences** (or `Ctrl+,`).
+- Security options are consolidated under **Preferences → Advanced → Security**.
+
+---
+
+## Troubleshooting
+
+If the app icon appears as a broken placeholder after a Flatpak install, the likely cause is a stale icon cache. See the [Troubleshooting section in the README](https://github.com/gwelr/ttyx_#troubleshooting) for the one-line fix and for Wayland Quake-mode notes.

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -1,0 +1,73 @@
+---
+title: Migrating from Tilix
+layout: default
+nav_order: 5
+permalink: /migrating/
+---
+
+# Migrating from Tilix
+
+If you already use [Tilix](https://github.com/gnunn1/tilix), ttyx_ migrates your configuration automatically on first run. You shouldn't need to do anything by hand; this page describes what happens under the hood and how to verify the migration worked.
+
+## What ttyx_ migrates automatically
+
+On first launch, if ttyx_ detects `~/.config/tilix/` and no pre-existing `~/.config/ttyx/`, it performs the following:
+
+- **Session files**: `~/.config/tilix/` is copied (not moved) to `~/.config/ttyx/`. The original directory is left in place as a backup until you decide to remove it.
+- **Saved passwords**: existing entries stored in libsecret under the old Tilix schema (`com.gexperts.tilix.Password`) are still readable by the password manager. New passwords you save from ttyx_ go under the new schema (`io.github.gwelr.ttyx.Password`), and deleting an entry removes it from whichever schema it was stored in.
+- **Shell integration**: terminals spawned by ttyx_ set both `TTYX_ID` and `TILIX_ID` environment variables, so existing shell-integration scripts (e.g. `tilix_int.sh`, now shipped as [`ttyx_int.sh`]({{ site.baseurl }}/manual/profileswitch/#remote-configuration) for new installs) continue to work during the transition.
+
+The migration is idempotent: if `~/.config/ttyx/` already exists, ttyx_ leaves everything alone and starts normally.
+
+## Security: symlink safety
+
+The migration refuses to follow symlinks during the copy. If a file in the source tree is a symlink (whether into or out of `~/.config/tilix/`), that entry is skipped and a warning is logged. This avoids a class of symlink-swap attacks where an attacker could redirect the migration to write outside your config directory.
+
+If you've set up legitimate symlinks inside `~/.config/tilix/` — for example syncing a subset of files via Syncthing — those entries will not be migrated. Either dereference them before first launch, or recreate them manually inside `~/.config/ttyx/` after launch.
+
+## What is *not* migrated
+
+- **GSettings preferences** (keybindings, profiles, global app settings). ttyx_ uses its own schema at `io.github.gwelr.ttyx` rather than `com.gexperts.Tilix`, and GSettings does not provide an automatic migration path between schemas. **Configure preferences in ttyx_ directly** on first launch. If you had an unusual setup under Tilix, keep a Tilix window open side-by-side to mirror the settings.
+- **Desktop entry overrides**: if you had a customized `~/.local/share/applications/com.gexperts.Tilix.desktop`, those changes don't carry over; ttyx_ ships its own desktop file under `io.github.gwelr.ttyx.desktop`.
+
+## Verifying the migration
+
+After first launch:
+
+```bash
+# Config dir is populated
+ls ~/.config/ttyx/
+
+# Original Tilix config is still in place
+ls ~/.config/tilix/
+
+# Saved passwords are readable (open the password manager and check the list)
+# Shell inside a ttyx_ terminal:
+echo "TTYX_ID=$TTYX_ID TILIX_ID=$TILIX_ID"
+```
+
+Both `TTYX_ID` and `TILIX_ID` should be set to the same UUID. Your saved passwords should be visible in **Preferences → Password Manager**.
+
+## Rolling back
+
+If something looks wrong and you want to revert to Tilix:
+
+1. Close ttyx_.
+2. Your original Tilix config is still at `~/.config/tilix/` — launch `tilix` and it will pick up from where it was.
+3. Optionally delete `~/.config/ttyx/` if you want a clean slate before trying ttyx_ again.
+
+Because migration only copies and never modifies the source, there is nothing to "undo" on the Tilix side.
+
+## Removing the old Tilix config
+
+Once you've confirmed ttyx_ is working the way you want, the Tilix backup is safe to remove:
+
+```bash
+rm -rf ~/.config/tilix/
+```
+
+You can do this at any time — ttyx_ no longer reads from `~/.config/tilix/` after the initial migration.
+
+## Uninstalling Tilix itself
+
+ttyx_ and Tilix can coexist on the same system; their binaries, icons, desktop files, and GSettings schemas don't collide. If you don't want Tilix installed anymore, uninstall it however your distro or package manager prefers (`apt remove tilix`, `flatpak uninstall com.gexperts.Tilix`, etc.) — that's independent of the ttyx_ migration.


### PR DESCRIPTION
Refs #62. Fourth PR in the Tier B documentation pass.

## What's in

Two new pages lifted from existing README content so the docs site can stand on its own without relying on README anchors, and so PR #8 (README trim) has something to link to.

### `docs/install.md` at `/install/`

- **Flatpak path** (recommended for direct users): download, `gpg --verify` the checksum signature, `sha256sum -c` the bundle, install, run.
- **Source path** (distro packagers, developers): Meson for Debian Stable / Ubuntu and Debian Testing / Sid (the archive dropped `libgtkd-3-dev` in testing, so we point at the CI helper script for building GtkD from source), plus the Dub alternative.
- First-launch notes linking to the migrating page and the security preferences location.
- Troubleshooting pointer to README's existing section.

### `docs/migrating.md` at `/migrating/`

- What gets migrated automatically (session files, libsecret entries, `TTYX_ID` / `TILIX_ID` dual env vars).
- **Symlink-safety note** — the migration refuses to follow symlinks, which matters if you sync a subset of `~/.config/tilix/` via Syncthing.
- What is *not* migrated (GSettings preferences, desktop-entry overrides).
- Verification commands + expected output.
- Rollback (the original `~/.config/tilix/` is preserved; ttyx_ never modifies it).
- Removing the old config, and independence from uninstalling Tilix itself.

### Landing page tweaks

The **Install** CTA button and the "Where to next" list now point at `/install/` and `/migrating/` on the site rather than at README anchors. Three CTA buttons remain: Install, Read the manual, View on GitHub.

## Sidebar order

Updated `nav_order`s to reflect the page hierarchy:

1. Home
2. Install (new)
3. What's new vs Tilix
4. Changelog
5. Migrating (new)
6. Manual

## Test plan

- [ ] Merge
- [ ] Wait for Pages rebuild
- [ ] Visit `https://gwelr.github.io/ttyx_/install/` — all install paths render, code blocks readable
- [ ] Visit `https://gwelr.github.io/ttyx_/migrating/` — sections render, internal link to manual/profileswitch/#remote-configuration resolves
- [ ] Landing Install button goes to `/install/`, not README
- [ ] Landing "Where to next" block has 6 entries, all links resolve

Assisted by Claude Code.