### PR TITLE
docs: Verify & fix existing manual pages — part 1 (title, quake, triggers, themes, badges)

### DIFF
--- a/docs/manual/badges.md
+++ b/docs/manual/badges.md
@@ -6,10 +6,29 @@ layout: default
 ---
 
 
-![]({{site.baseurl}}/assets/images/manual/badges.png)
+![Example of a terminal badge displaying text overlaid on the terminal background]({{site.baseurl}}/assets/images/manual/badges.png)
 
-Badges are a feature that displays specified text in the background of the terminal. They can be used for a variety of purposes including acting as visual reminders or as a way to display the terminal title when the title is disabled.
+## Overview
 
-Badges are configured at the Profile level and are specific to a Profile. The General page of Profile preferences allows you to specify the badge text and the position of the badge. Note that badges support all of the same variables as terminal titles, so you can specify something like ```${title}``` to display the title in the badge. See the FAQ for a list of variables that are available.
+Badges are text overlays displayed in the background of the terminal. They can act as visual reminders (e.g. environment name, pod name), or as a way to show the terminal title when the title bar is disabled.
 
-The color of the badge can be configured in the Colors page of Profile preferences and is nested within the Advanced popup. Additionally, the badge color can be specified in the theme files.
+## Configuration
+
+Badges are configured at the **Profile** level and are per-profile.
+
+- **Text and position** are set on the **General** tab of Profile preferences. Position is one of the four corners of the terminal (top-left, top-right, bottom-left, bottom-right) plus a centered option.
+- **Color** is set on the **Colors** tab of Profile preferences, under the **Advanced** popup. The badge color can also be specified in a theme file — see the [`badge-color`]({{ site.baseurl }}/manual/themes/) field.
+
+## Variables
+
+Badges support the full set of variables described on the [Titles]({{ site.baseurl }}/manual/title/) page. Common examples:
+
+| Badge text | Result |
+|------------|--------|
+| `${title}` | The terminal's current title |
+| `${hostname}` | The hostname reported by the shell (requires a configured trigger or VTE script) |
+| `${directory}` | The current working directory |
+| `${id}` | The numeric terminal ID |
+| `PROD — ${username}@${hostname}` | Freeform text combined with substitutions |
+
+Triggers can also update the badge dynamically via the [Update Badge]({{ site.baseurl }}/manual/triggers/#supported-actions) action — useful for displaying state extracted from terminal output.

--- a/docs/manual/quake.md
+++ b/docs/manual/quake.md
@@ -5,29 +5,42 @@ nav_order: 2
 layout: default
 ---
 
-#### Introduction
+## Overview
 
-ttyx_ supports running in a _Quake_-style mode where it appears at the top of the screen and can be toggled on or off as needed. However, unlike other terminal emulators that support this mode ttyx_ does not register a global hot key. Instead you must register a hot key yourself with the Desktop Environment you are using, this is required because Wayland does not support global hot keys.
+ttyx_ supports running in a _Quake_-style mode where it appears at the top of the screen and can be toggled on or off on demand. Unlike most terminal emulators that offer this feature, ttyx_ does **not** register a global hot key itself — you register one with your desktop environment. Wayland doesn't expose global hot keys to applications, so this is the only portable approach.
 
-When you register the hot key, simply bind it to the following command:
+When you register the hot key, bind it to the following command:
 
 {% highlight bash %}
 ttyx --quake
 {% endhighlight %}
 
-When ttyx_ is run with the `--quake` switch, it will check if a quake style window is already running and if so simply toggle the window's visibility. If no quake style window has been created, then ttyx_ will create one and display it.
+When `ttyx --quake` runs, it checks whether a quake-style window already exists and toggles its visibility if so. Otherwise it creates a new one and shows it.
 
-Configuring this hot key for GNOME is quite simple, simply open the Keyboard settings and configure a hot key as per the example in the screenshot below:
+## Configuring the hot key in GNOME
 
-![]({{site.baseurl}}/assets/images/manual/hotkey.png)
+Open GNOME's Keyboard settings and add a custom shortcut matching the screenshot below:
 
-#### Wayland
+![GNOME custom shortcut for ttyx --quake]({{site.baseurl}}/assets/images/manual/hotkey.png)
 
-Note that quake mode in Wayland is currently not available, while initially supported it proved to be problematic given the limitations of the Wayland environment. Here are the options for enabling in Wayland:
+## Wayland
 
-* Force the GDK back-end to be X11. You can force ttyx_ to use X11 as the backend instead of Wayland by setting the quake command as ```GDK_BACKEND=x11 ttyx --quake```. Note that you should also update the ttyx_ desktop file to force the x11 backend as well.
-* There is a gnome-shell [quake](https://github.com/repsac-by/gnome-shell-extension-quake-mode) extension that enables any application to run in quake mode.
+Quake mode relies on X11 window-positioning APIs that Wayland compositors don't expose to applications, so behaviour is compositor-dependent. GNOME Shell in particular cannot position windows from the application side. See the [README's Troubleshooting section](https://github.com/gwelr/ttyx_#quake-mode-doesnt-position-correctly-wayland) for the current state.
 
-### KDE
+Two workarounds:
 
-If you have the issue where the quake window does not receive focus, try disabling the feature "Focus stealing prevention" in KDE (the linked comment was originally filed against upstream Tilix: [here](https://github.com/gnunn1/tilix/issues/895#issuecomment-385275324)).
+- **Use an X11 session.** ttyx_'s desktop file already prefers X11 when available. If you're on a distro that ships Wayland by default, you can force a single ttyx_ launch to use X11 with:
+
+  {% highlight bash %}
+  GDK_BACKEND=x11 ttyx --quake
+  {% endhighlight %}
+
+  To make this permanent, override the bundled desktop file in `~/.local/share/applications/io.github.gwelr.ttyx.desktop` and set `Exec=env GDK_BACKEND=x11 ttyx --quake`.
+
+- **Use a GNOME Shell quake extension** that handles the positioning on the compositor side, for example [gnome-shell-extension-quake-mode](https://github.com/repsac-by/gnome-shell-extension-quake-mode), which can put any application into quake mode without the app needing native support.
+
+On wlroots-based compositors (Sway, Hyprland, Wayfire), first-class support may arrive in a future release via the `wlr-layer-shell` protocol — see the [ROADMAP](https://github.com/gwelr/ttyx_/blob/master/ROADMAP.md) for status.
+
+## KDE
+
+If the quake window doesn't receive focus on KDE, try disabling the **Focus stealing prevention** feature. This was originally reported against upstream Tilix — see the workaround in [this issue comment](https://github.com/gnunn1/tilix/issues/895#issuecomment-385275324).

--- a/docs/manual/themes.md
+++ b/docs/manual/themes.md
@@ -5,7 +5,9 @@ nav_order: 4
 layout: default
 ---
 
-ttyx_ supports themes for configuring the color scheme of the terminal, each theme is stored in a file. A theme file is a simple json file that specifies the color for each element as well as identifying whether certain colors should be used or defaulted. Here is an example of a theme file:
+## Overview
+
+ttyx_ supports themes for configuring the color scheme of the terminal, one theme per JSON file. Each theme specifies colors for each element and declares whether certain colors should be used or left to the GTK theme. Here is an example of a theme file:
 
 {% highlight json %}
 {
@@ -43,6 +45,37 @@ ttyx_ supports themes for configuring the color scheme of the terminal, each the
 }
 {% endhighlight %}
 
-Themes are loaded from one of two places by ttyx_. The first is ```/usr/share/ttyx/schemes```, these are the themes that are shipped with ttyx_. The second place that ttyx_ looks for theme files is in the user home directory, specifically ```~/.config/ttyx/schemes```. Users can place any custom themes they want to use here.
+## Where themes are loaded from
 
-While ttyx_ only includes a small number of themes, additional themes can be easily downloaded and installed. Community theme repositories originally built for Tilix use a compatible JSON format, for example [Tilix-Themes](https://github.com/storm119/Tilix-Themes) and [gogh-to-tilix](https://github.com/isacikgoz/gogh-to-tilix).
+ttyx_ looks for theme files in two locations, in order:
+
+1. `~/.config/ttyx/schemes/` — user-installed themes. Drop any JSON file here and it will appear in the theme picker.
+2. `/usr/share/ttyx/schemes/` — themes shipped with ttyx_.
+
+If a theme with the same name exists in both locations, the user version wins. This fix shipped in v1.1.1; before then, duplicates could appear in the theme picker.
+
+## Bundled themes
+
+ttyx_ ships 17 schemes out of the box, covering the most commonly-requested palettes:
+
+- **Catppuccin** — Latte, Mocha
+- **Dracula**
+- **Gruvbox** — Dark, Light
+- **Nord**
+- **Solarized** — Dark, Light
+- **Tokyo Night**
+- **One Dark**
+- **Material**
+- **Monokai**
+- **Tango**
+- **Base16 Twilight (dark)**
+- **Linux console**, **Orchis**, **Yaru**
+
+## Installing additional themes
+
+Any JSON file following the structure above works. Two community theme repositories originally built for Tilix use the same format and install into `~/.config/ttyx/schemes/`:
+
+- [**Tilix-Themes**](https://github.com/storm119/Tilix-Themes) — a large collection of pre-built palettes.
+- [**gogh-to-tilix**](https://github.com/isacikgoz/gogh-to-tilix) — a converter for the [gogh](https://github.com/Gogh-Co/Gogh) theme ecosystem.
+
+After dropping a new `.json` file into `~/.config/ttyx/schemes/`, it appears in **Preferences → Profile → Color → Color scheme** without a restart.

--- a/docs/manual/title.md
+++ b/docs/manual/title.md
@@ -5,7 +5,7 @@ nav_order: 1
 layout: default
 ---
 
-ttyx_ support using variables in the various titles and names it allows to be configured. This enables the title to better reflect the current state of the application, session or currently focused terminal. Variables are available within a particular scope and can always be used in higher scopes. For example, the ${title} is a terminal scope variable but can be used in session and application titles where it reflects the currently active terminal.
+ttyx_ supports using variables in the various titles and names it allows to be configured. This enables the title to better reflect the current state of the application, session, or currently focused terminal. Variables are available within a particular scope and can always be used in higher scopes. For example, `${title}` is a terminal-scope variable but can be used in session and application titles — there it reflects the currently active terminal.
 
 Variables can be used in the following locations:
 
@@ -16,32 +16,40 @@ Variables can be used in the following locations:
 * Custom links
 * Triggers
 
-The following variables are supported at **terminal** scope and are determined based on the currently focused terminal:
+## Terminal scope
 
-Variable | Description
--------|------------
-${title} | The title of the terminal as reported by the terminal
-${iconTitle} | The icon title of the terminal
-${id} | The numeric terminal ID (i.e. 1,2,3,4)
-${directory} | The current working directory in the terminal
-${columns} | The number of columns in the terminal
-${rows} | the number of rows in the terminal
-${hostname} | the hostname of the current session, availability dependent on the VTE script being configured on remote systems or triggers
-${username} | the current username, requires trigger support and an appropriate trigger be configured
+These variables are resolved against the currently focused terminal:
 
-These variables are available at **session** scope:
+| Variable | Description |
+|----------|-------------|
+| `${title}` | The title of the terminal as reported by the terminal |
+| `${iconTitle}` | The icon title of the terminal |
+| `${id}` | The numeric terminal ID (e.g. 1, 2, 3, 4) |
+| `${directory}` | The current working directory in the terminal |
+| `${columns}` | The number of columns in the terminal |
+| `${rows}` | The number of rows in the terminal |
+| `${hostname}` | The hostname of the current session. Availability depends on having the VTE script configured on remote systems, or on a trigger extracting the value from terminal output |
+| `${username}` | The current username. Requires trigger support and an appropriate trigger to be configured |
+| `${process}` | The active foreground process name (e.g. `vim`, `ssh`). Requires the process monitor to be enabled in Preferences |
+| `${status.readonly}` | `true` if the terminal has input disabled, `false` otherwise |
+| `${status.silence}` | `true` if the terminal is being monitored for silence, `false` otherwise |
+| `${status.input-sync}` | `true` if the terminal is part of a synchronized-input group, `false` otherwise |
 
-Variable | Description
--------|------------
-${activeTerminalTitle} | The title of the current terminal with all variables substituted.
-${terminalCount} | The total number of terminals in the session
-${terminalNumber} | The number of the currently active terminal
+## Session scope
 
-The following additional variables are supported in all titles except terminal titles:
+| Variable | Description |
+|----------|-------------|
+| `${activeTerminalTitle}` | The title of the currently active terminal with all variables substituted |
+| `${terminalCount}` | The total number of terminals in the session |
+| `${terminalNumber}` | The number of the currently active terminal |
 
-Variable | Description
--------|------------
-${appName} | The name of the application, i.e. ttyx_
-${sessionName} | The name of the session
-${sessionCount} | The total number of sessions
-${sessionNumber} | The number of the session, i.e. session 2 out of 4 active
+## Application scope
+
+Available in all titles except the per-terminal title.
+
+| Variable | Description |
+|----------|-------------|
+| `${appName}` | The name of the application — `ttyx_` |
+| `${sessionName}` | The name of the session |
+| `${sessionCount}` | The total number of sessions |
+| `${sessionNumber}` | The number of the current session (e.g. session 2 of 4) |

--- a/docs/manual/triggers.md
+++ b/docs/manual/triggers.md
@@ -7,47 +7,47 @@ layout: default
 
 *Historically, trigger support required a [Tilix-specific patch](https://github.com/gnunn1/tilix/blob/master/experimental/vte/alternate-screen.patch) on top of GTK VTE (Arch users installed the [vte3-tilix-git](https://aur.archlinux.org/packages/vte3-tilix-git) package). Recent VTE releases include the alternate-screen support needed for triggers to work without a custom patch.*
 
-#### Introduction
+## Overview
 
-ttyx_ supports the concept of triggers, these are regular expressions defined by the user that when matched against text output by the terminal trigger an action. A trigger consists of a regular expression, the action to execute and a parameter string. Depending on the action, the parameter may not be used at all, may be a single string or a semi-colon delimited list of variables.
+ttyx_ supports triggers: regular expressions defined by the user that, when matched against text output by the terminal, execute an action. A trigger consists of a regular expression, the action to execute, and a parameter string. Depending on the action, the parameter may not be used at all, may be a single string, or may be a semicolon-delimited list of `name=value` pairs.
 
-The result of the regular expression can be referenced as tokens in the parameter, ttyx_ will substitute the tokens in the parameter prior to executing the action. The token $0 refers to the complete regular expression match. If groups were defined in the regular expression, the tokens $1, $2, $3, etc refer to the individual group captures.
+Capture groups in the regular expression are available as tokens in the parameter. ttyx_ substitutes these tokens before executing the action:
 
-#### Supported Actions
+- `$0` — the complete regular expression match.
+- `$1`, `$2`, `$3`, … — the individual capture groups when defined.
 
-The following actions are supported by ttyx_:
+## Supported actions
 
-Action | Description
--------|------------
-Update State | This action updates the state that ttyx_ maintains about the terminal in terms of things like what directory or hostname is currently active in the terminal. The variables *username*, *hostname* and *directory* can be used to update the state respectively, these represent . See further below for an example of how to use this.
-Execute Command | This action executes the command provided in the parameter field.
-Send Notification | Sends a notification to the desktop environment. Two variables are supported by this action, *title* and *body*.
-Update Title | Updates the terminal title using the parameter field, it sets the override title specified in Layout Options.
-Play Bell | Plays the bell noise, this action takes no parameters
-Send Text | Sends the text in the parameter field to the terminal
-Insert Password | Shows the password manager to enable a password to be inserted into the terminal
+| Action | Parameter | Description |
+|--------|-----------|-------------|
+| Update State | `username=…;hostname=…;directory=…` | Updates the internal state ttyx_ keeps about the terminal. Used by features like titles, the path-aware working directory, and profile switching. Any subset of `username`, `hostname`, `directory` may be provided. |
+| Execute Command | shell command | Spawns the given command in the shell. |
+| Send Notification | `title=…;body=…` | Sends a desktop notification. Both keys are optional; if `body` is omitted, the full regex match (`$0`) is used as the body. |
+| Update Badge | text | Sets the terminal's badge overlay to the substituted text. See [Badges]({{ site.baseurl }}/manual/badges/). |
+| Update Title | text | Sets the terminal's override title (same as the Layout Options override). |
+| Play Bell | — | Plays the terminal bell. No parameter. |
+| Send Text | text | Sends the substituted text to the terminal as if typed. |
+| Insert Password | — | Opens the password manager so you can pick an entry to insert. |
+| Run Process | command | Runs the given command outside the terminal (detached), without sending any output back to the shell. |
 
-#### Options
+## Trigger-line limit
 
-ttyx_ has an option to limit the number of lines that are checked for triggers, this is intended to improve performance on slower hardware. Every time a change happens in the terminal, this is reported to ttyx_ as a block of text. This block might consist of just a single character when the user is typing, or it might consist of several thousand lines when outputting a large text file via cat.
+ttyx_ limits the number of lines checked for triggers by default. This keeps performance steady on slower hardware when a large block of output arrives (e.g. `cat` on a big file).
 
-In the later scenario, we may generally not be too interested in checking for triggers in all lines of text. When this option is active, ttyx_ will only check the lines changed from the end of the text. So for example, if a block of text consisting of 20,000 lines of text was received but the option limit was active at 256, only the last 256 lines would be checked.
+Every change in the terminal is delivered to ttyx_ as a block of text. A block might be a single keystroke, or it might be thousands of lines at once. When the trigger-line limit is active, only the last N lines of each block are scanned; so if a 20,000-line block arrives and the limit is 256, only the trailing 256 lines get trigger-matched.
 
-#### Examples
+If you need triggers to fire on every line regardless of block size, disable the limit from Preferences. Doing so can have a noticeable performance cost during bulk output.
 
-Here are some examples to help you use this feature:
+## Example
 
-Regular Expression | Action | Parameter | Description
--------------------|--------|-----------|------------
-```^\[(?P&lt;user>.*)@(?P&lt;host>[-a-zA-Z0-9]*)``` | Update State | username=$1;hostname=$2 | Parses the username and hostname from a Linux prompt command that uses the following format: *[username@hostname directory]$*
+| Regular expression | Action | Parameter | Description |
+|-------------------|--------|-----------|-------------|
+| `^\[(?P<user>.*)@(?P<host>[-a-zA-Z0-9]*)` | Update State | `username=$1;hostname=$2` | Parses the username and hostname from a Linux prompt formatted as `[user@host directory]$`. |
 
-#### How It Works
+## How it works
 
-To get the most of out of this feature, it's important to understand how this works under the hood. As an overview, ttyx_ uses a GTK component called the VTE to perform the actual terminal emulation. When changes occur in the VTE, it triggers an event to notify ttyx_ but does not include any information about the change itself. In order to execute triggers, ttyx_ saves the current row and column reported by the VTE so that when the next change event happens only the delta is processed for triggers.
+ttyx_ relies on GTK's VTE component to perform the actual terminal emulation. When VTE's buffer changes, it signals ttyx_ but does not include information about what changed. ttyx_ records the current row/column position on each signal so that it can compute the delta the next time a change arrives, and runs triggers only against that delta.
 
-This means that any change in the terminal will be processed but the grouping of these changes is entirely up to the VTE. For example, when typing text ttyx_ will run triggers against each character entered by the user individually, it does not run triggers against the full command. 
+One consequence: the **grouping of changes is entirely up to VTE**. When typing, VTE signals after each character, so triggers run against individual characters, not full commands. When outputting large amounts of text (e.g. `cat`-ing a large file), VTE batches changes in very large chunks — this keeps framerate stable by coalescing updates. If the scrollback buffer overflows during one of these bursts, the overflowing text has already scrolled out of range and is no longer matchable.
 
-When outputting large amounts of text, i.e. cat'ing a large file, the VTE tends to report changes in very large chunks. This makes perfect sense the VTE needs to maintain a certain level of performance and caps the framerate by omitting rendering of text when it is not needed. As a result, when the scrollback buffer is limited (default in ttyx_ is 8192), not all of the text may be available to ttyx_ since it has already scrolled out of range of the buffer.
-
-Thus if you want ttyx_ to process triggers for every line of text, you must set the scrollback buffer to unlimited and the trigger lines option to unlimited.
-
+To maximize trigger coverage on large output: raise the scrollback buffer (`scrollback-lines`, maximum 999,999 in ttyx_) and disable the trigger-line limit. The unlimited-scrollback option from upstream Tilix was removed for [memory-safety reasons]({{ site.baseurl }}/security/#in-memory-only-scrollback), so 999,999 is the current ceiling.


### PR DESCRIPTION
Refs #62. Seventh PR in the Tier B documentation pass (split into 7a and 7b). Adds content corrections and structural cleanup after cross-checking the imported Tilix manual pages against the current ttyx_ code.

## Real content fixes (not cosmetic)

### `title.md`

**Missing variables.** The imported doc listed 8 terminal-scope variables. The code in `source/gx/tilix/constants.d` and `replaceVariables()` in `terminal.d` defines 12. Added the four that were missing:

- `${process}` — active foreground process name; requires the process monitor enabled.
- `${status.readonly}` — boolean, terminal input disabled.
- `${status.silence}` — boolean, silence monitoring active.
- `${status.input-sync}` — boolean, synchronized-input group member.

### `triggers.md`

**Missing actions.** The imported doc listed 7 trigger actions. The code's `final switch (trigger.action)` in `terminal.d` handles 9. Added:

- **Update Badge** — sets the terminal's badge overlay.
- **Run Process** — runs a detached command outside the terminal (no output back to the shell).

**Unfinished sentence.** The Update State description ended with `"these represent ."` — corrected to describe what the three state keys (`username`, `hostname`, `directory`) represent.

**Outright wrong advice.** The page instructed setting the scrollback buffer to **unlimited**. The unlimited option was removed in ttyx_ v1.1.0 for memory-safety reasons (scrollback is now in-memory-only). Corrected to "raise to 999,999 lines" with a cross-link to `/security/#in-memory-only-scrollback` explaining why.

### `themes.md`

**"Only includes a small number of themes"** was factually off — ttyx_ ships **17 schemes**. Added the full list (Catppuccin Latte/Mocha, Dracula, Gruvbox Dark/Light, Nord, Solarized Dark/Light, Tokyo Night, One Dark, Material, Monokai, Tango, Base16 Twilight, Linux, Orchis, Yaru).

**User-over-system precedence** for duplicate scheme names (v1.1.1 fix) now documented. Previously, a user scheme with the same name as a system one could cause duplicates in the picker.

### `badges.md`

Replaced "see the FAQ for variables" (there is no FAQ) with cross-links to the [Titles]({{ site.baseurl }}/manual/title/) page and a common-case examples table. Added a cross-link to Update Badge on the triggers page for dynamic-from-output usage.

## Structural cleanup (all pages)

- Normalized heading levels — pages were a mix of `####`, `###`, inline text. Now consistent `##` / `###`.
- Promoted bare pipe-tables to proper Markdown tables with a header separator.
- Added alt text on the badges screenshot.
- `quake.md` Wayland section restructured around the two real workarounds (force X11 / use compositor extension) with a concrete desktop-file override example for the X11 path.

## Test plan

- [ ] Merge
- [ ] Wait for Pages rebuild
- [ ] Visit each of the five pages and confirm:
  - Tables render correctly
  - Cross-links resolve (`/manual/title/`, `/manual/triggers/#supported-actions`, `/security/#in-memory-only-scrollback`)
  - Images still load (badges, hotkey)

Part 2 will cover the remaining five pages: profileswitch, customlinks, margin, vteconfig, cliactions.

Assisted by Claude Code.