### PR TITLE
docs: Verify & fix existing manual pages — part 2 (profileswitch, customlinks, margin, vteconfig, cliactions)

### DIFF
--- a/docs/manual/cliactions.md
+++ b/docs/manual/cliactions.md
@@ -5,26 +5,31 @@ nav_order: 10
 layout: default
 ---
 
-#### Introduction
+## Overview
 
-ttyx_ supports the use of command line actions to have the running instance execute an action that you would typically do through the user interface. The use case for this functionality is to be able run a script within ttyx_ that causes it to perform certain commands. For example, to have ttyx_ run the command ```yaourt -Syua``` in a new terminal that is split right, the following command can be used:
+ttyx_ can be driven from the command line via the `--action` (or `-a`) switch, which tells a running ttyx_ instance to execute an action you'd normally trigger from the UI. Useful for scripting: a shell alias or a desktop-file launcher can open a split, a new window, or a new session without you touching the keyboard.
 
+Example — open a split-right terminal and run `yay -Syua` in it:
 
 {% highlight bash %}
-ttyx -a session-add-right -x "yaourt -Syua"
+ttyx -a session-add-right -x "yay -Syua"
 {% endhighlight %}
 
-The ```-a```, or ```--action```, command line switch is what is used to specify the action to be executed. Any action executed is always done relative to the terminal where the command was executed. Any command line parameters that are specified as part of the command get passed to the new terminal. This allows you to do a variety of things such as use a different profile, specify the working directory or as per the example above, execute a command.
+Actions are always executed **relative to the terminal where the command was invoked**. Command-line parameters that aren't consumed by ttyx_ flags are passed to the new terminal, so you can combine `-a` with `-p` (profile), `-w` (working directory), `-x` (execute command), etc.
 
-#### Supported Actions
+## Supported actions
 
-The actions are specified using the same keys you see in dconf for the key shortcuts at ```/io/github/gwelr/ttyx/keybindings```. While any action shown here can be sent via the action parameter, not all of them are supported or will work. Some of the actions, such as Synchronize Input, would require additional parameters to function correctly.
+The action names mirror keybinding names under `/io/github/gwelr/ttyx/keybindings` in dconf. Not every keybinding is meaningful as a command-line action (some require in-UI context like the currently selected synchronized-input group). The four officially supported actions:
 
-The table below is the list of officially supported actions at this time:
+| Action | Effect |
+|--------|--------|
+| `session-add-right` | Split the current terminal right |
+| `session-add-down` | Split the current terminal down |
+| `app-new-window` | Create a new ttyx_ window |
+| `app-new-session` | Create a new session in the current window |
 
-Action | Description
--------|------------
-session-add-right | Splits the terminal right
-session-add-down | Splits the terminal down
-app-new-window | Creates a new ttyx_ window
-app-new-session | Creates a new ttyx_ session
+## Gotchas
+
+- **You must have a running ttyx_ instance** for `-a` to have anywhere to act. If no instance is running, ttyx_ starts one and the action silently no-ops.
+- **The action runs against the focused terminal** of the running instance, which may not be the terminal you invoked the command from if you have multiple windows open.
+- **`-x` with quoting**: if your command contains shell metacharacters, quote it aggressively (`-x "echo hello; echo world"`) — ttyx_ passes the string to the shell so quoting follows shell rules.

--- a/docs/manual/customlinks.md
+++ b/docs/manual/customlinks.md
@@ -5,10 +5,27 @@ nav_order: 7
 layout: default
 ---
 
-ttyx_ allows custom hyperlinks to be defined using regular expressions. These links can then be clicked on to launch an application passing information from the match to the application.
+## Overview
 
-When configuring the application to be launched, the token ```$0``` can be used to represent the match obtained from the regular expression. If the regular expression includes groups then ```$1``` is the first group, ```$2``` the second group, etc.
+ttyx_ lets you define custom hyperlinks using regular expressions. Any text matching a configured pattern becomes clickable in the terminal; clicking launches a command with the match (or its capture groups) as arguments.
 
-Here is a screenshot showing an example of using this feature to launch gedit with the filename and line number based on a regular expression that includes two groups.
+## Configuration
 
-![]({{site.baseurl}}/assets/images/manual/links.png)
+Custom links are configured at the **Profile** level in **Preferences → Profile → Advanced → Custom Links**. Each entry has two fields:
+
+- **Regex** — the pattern to match in terminal output.
+- **Command** — the command to run when the match is clicked. Use `$0` for the full match, `$1`, `$2`, … for capture groups.
+
+## Example
+
+![gedit launched with filename and line number from a Python traceback]({{site.baseurl}}/assets/images/manual/links.png)
+
+The screenshot shows a regex that matches `File "path", line N` in a Python traceback and a command that opens `gedit` at the right file and line. The regex has two capture groups (file path and line number), used as `$1` and `$2` in the command.
+
+Any command on `$PATH` works — common uses:
+
+| Pattern | Matches | Command |
+|---------|---------|---------|
+| `File "([^"]+)", line (\d+)` | Python tracebacks | `gedit +$2 $1` |
+| `([a-zA-Z0-9_/\.-]+\.[a-z]+):(\d+)` | `file:line` style | `$EDITOR +$2 $1` |
+| `https?://\S+` | URLs (built in, but you can override) | `xdg-open $0` |

--- a/docs/manual/margin.md
+++ b/docs/manual/margin.md
@@ -5,8 +5,19 @@ nav_order: 8
 layout: default
 ---
 
-![]({{site.baseurl}}/assets/images/manual/margin.png)
+![Terminal with a vertical margin line at column 80]({{site.baseurl}}/assets/images/manual/margin.png)
 
-Many code standards require line length always be under a prescribed limit to maintain readability. When using text editors like vi, emacs or nano it can be useful to have a margin indicating where this limit is. ttyx_ allows you to configure the limit on a per profile basis and then toggle the margin line on or off via a shortcut. The default shortcut is ctrl-alt-m.
+## Overview
 
-This is available as of ttyx_ 1.8.1.
+Many style guides require lines to stay under a fixed column width (typically 80 or 100 characters) to keep code readable. When using text-mode editors like `vi`, `emacs`, or `nano`, a visible margin line makes it easy to see when you're about to go over.
+
+## Configuration
+
+Margin width is configured per-profile in **Preferences → Profile → Scrolling**.
+
+| GSetting | Key | Default | Meaning |
+|----------|-----|---------|---------|
+| Margin column | `draw-margin` | `80` | Column to draw the margin line at; `0` disables the margin entirely |
+| Toggle shortcut | `terminal-toggle-margin` | `<Ctrl><Alt>m` | Keyboard shortcut to toggle the margin on and off without changing the profile setting |
+
+The toggle is useful when you want the margin visible while editing but out of the way while reading long output.

--- a/docs/manual/profileswitch.md
+++ b/docs/manual/profileswitch.md
@@ -5,30 +5,46 @@ nav_order: 6
 layout: default
 ---
 
-#### Introduction
+## Overview
 
-ttyx_ supports automatically switching profiles based on certain conditions which is useful in a variety of situations such as when switching users, connecting to different hosts, changing to sensitive directories, etc. At the moment ttyx_ supports triggering a profile change based on the following:
+ttyx_ can switch profiles automatically based on context — useful for switching users, connecting to different hosts, or marking sensitive directories. Profile changes can be triggered on any of:
 
-* username
-* hostname
-* current directory
+* **username** — extracted from the shell prompt via a trigger
+* **hostname** — reported by the shell (local, or OSC 7 from a remote)
+* **current directory** — the terminal's cwd
 
-Note that when an automatic profile change is active, the menu to switch to different profiles will be disabled.
+When an automatic profile change is active, the manual profile picker is disabled so you can't accidentally override it.
 
-#### Local Configuration
+## Local configuration
 
-Configuring profile switching in ttyx_ is done in the Advanced tab of the profile settings. Here you can configure the list of usernames, hostnames and directories that will trigger the profile change. The format used for the string is ```username@hostname:directory``` where either username, hostname or directory can be omitted but not all. Also at least one delimiter, either *@* or *:*, is also required to indicate which string is being represented.
+Configure profile switching in **Preferences → Profile → Advanced**. Each entry in the match list uses the format:
 
-**Note** that switching profiles based on username requires the use of a trigger to extract the username from the terminal output text. Triggers in turn require a patched VTE, see the [Triggers]({{ site.baseurl }}/manual/triggers/) page for more information.
+```
+username@hostname:directory
+```
 
-#### Remote Configuration
+Any one of `username`, `hostname`, or `directory` may be omitted, but at least one must be present and at least one delimiter (`@` or `:`) is required to indicate which string is which.
 
-To enable profile changes when using SSH to connect to remote systems, the remote system must be configured to include an additional script or an appropriate trigger configured. 
+**Username-based switching** requires extracting the username from terminal output via a [trigger]({{ site.baseurl }}/manual/triggers/). See the Triggers page for the `Update State` action with a `username=$1` parameter.
 
-If you opt for the script, first scp the script ```/usr/share/ttyx/scripts/ttyx_int.sh``` from your local system where ttyx_ is installed to the remote system. You will then need to source this script on the remote system, the easiest way to do this is to modify the .bashrc of the user you use to connect to include the script. For example, add the following to .bashrc:
+## Remote configuration
+
+To enable profile changes when SSHing into remote systems, the remote shell needs to report the working directory and/or hostname back to ttyx_. Two options:
+
+### 1. Use the bundled integration script (recommended)
+
+ttyx_ ships `/usr/share/ttyx/scripts/ttyx_int.sh`, which reports the current directory back via OSC 7 escape sequences. Copy it to the remote host and source it from your shell rc:
 
 {% highlight bash %}
-. ./ttyx_int.sh
+# On your local system:
+scp /usr/share/ttyx/scripts/ttyx_int.sh user@remote:~/
+
+# On the remote system, add to ~/.bashrc or ~/.zshrc:
+. ~/ttyx_int.sh
 {% endhighlight %}
 
-if you switch users on the remote system, you may need to source the script somewhere so it is available to all users.
+If you switch users on the remote system, source the script somewhere available to all users (e.g. `/etc/profile.d/`) so it applies to every shell.
+
+### 2. Configure a trigger
+
+Alternatively, a trigger against the shell prompt can extract both username and hostname without a helper script. See the [Triggers example]({{ site.baseurl }}/manual/triggers/#example) — a regex against a `[user@host dir]$` prompt feeds the Update State action.

--- a/docs/manual/vteconfig.md
+++ b/docs/manual/vteconfig.md
@@ -5,42 +5,50 @@ nav_order: 9
 layout: default
 ---
 
-#### Background
+## Background
 
-ttyx_ uses a GTK+ 3 widget called VTE (Virtual Terminal Emulator). The VTE widget was originally designed as the back-end for Gnome Terminal but was fortunately designed as a GTK widget so that other terminal emulator applications could leverage it instead of rolling their own. Many popular Linux terminal emulators use this component.
+ttyx_ uses a GTK+ 3 widget called **VTE** (Virtual Terminal Emulator), originally built as the back-end for GNOME Terminal and now used by most GTK-based terminal emulators including ttyx_.
 
-One aspect of VTE configuration is the use of /etc/profile.d/vte.sh. The VTE uses this script to override the PROMPT_COMMAND in order to feed itself additional information via terminal control codes. In particular, this script is used to tell the VTE the current directory of the shell. Previously the VTE component used to read this from /proc/&lt;pid&gt;/cwd however according to [VTE upstream](https://bugzilla.gnome.org/show_bug.cgi?id=697475) there were a number of issues with this approach and hence the change to /etc/profile.d/vte.sh.
+VTE relies on a helper script — typically `/etc/profile.d/vte.sh` — to hook the shell's `PROMPT_COMMAND` and emit terminal control codes that tell the emulator what directory the shell is in. Earlier VTE versions read this from `/proc/<pid>/cwd`, but that approach had [reliability issues](https://bugzilla.gnome.org/show_bug.cgi?id=697475), so VTE moved to the script-based approach.
 
-The issue with this change though is that different distributions treat /etc/profile.d differently. The expectation is that when a shell is initiated all scripts in /etc/profile.d are executed. On Fedora, this works as expected for both login and non-login based shells. However, other distributions (Ubuntu and Arch at least) only execute scripts in /etc/profile.d for login shells. The problem with this is the default configuration for most terminal emulators using VTE, including Gnome Terminal and ttyx_, is to not run the shell as a login shell.
+The catch: different distributions treat `/etc/profile.d/` differently. On Fedora, scripts there run for both login and non-login shells; on Ubuntu and Arch, they only run for login shells. Since most terminal emulators — including ttyx_ — don't launch shells as login shells by default, the VTE hook never fires.
 
-#### Impact
+## Impact
 
-This means that on some Linux distributions vte.sh never gets executed and VTE loses certain features that are dependent on the PROMPT_COMMAND. In particular, the two features that we know are impacted:
+When the VTE helper doesn't run, the current directory stops being reported. Concretely: splitting a terminal in ttyx_ opens the split in your home directory instead of inheriting the parent's cwd.
 
-* The current directory is never reported by VTE. This means when splitting terminals in ttyx_ instead of inheriting the directory from the current terminal the split terminal always opens in your home terminal. Gnome Terminal has the same issue when creating new tabs
-* The Fedora patched VTE that provides notification support depends on PROMPT_COMMAND, so this issue means notifications will not work.
+## Fixing it
 
-#### Fixing the issue
+Pick whichever is easiest.
 
-Fortunately fixing this issue is quite easy, you can do either of the two options below.
+### Option 1 — Use the bundled ttyx_ integration script
 
-##### 1. Source vte.sh in bashrc
+ttyx_ ships its own integration script at `/usr/share/ttyx/scripts/ttyx_int.sh` that does the same job as `vte.sh`: it hooks `PROMPT_COMMAND` to emit OSC 7 sequences telling the emulator the shell's cwd. Source it from your rc file:
 
-Update ```~/.bashrc``` (or ```~/.zshrc``` if you are using zsh) to execute vte.sh directly, this involves adding the following line at the end of the file.
 {% highlight bash %}
-if [ $TILIX_ID ] || [ $VTE_VERSION ]; then
-        source /etc/profile.d/vte.sh
+# ~/.bashrc or ~/.zshrc
+. /usr/share/ttyx/scripts/ttyx_int.sh
+{% endhighlight %}
+
+This is also the recommended approach for [remote hosts over SSH]({{ site.baseurl }}/manual/profileswitch/#remote-configuration).
+
+### Option 2 — Source vte.sh manually
+
+Add this to `~/.bashrc` (or `~/.zshrc`):
+
+{% highlight bash %}
+if [ "$TTYX_ID" ] || [ "$TILIX_ID" ] || [ "$VTE_VERSION" ]; then
+    source /etc/profile.d/vte.sh
 fi
 {% endhighlight %}
 
-On Ubuntu (16.04 or 16.10), a symlink is probably missing. You can create it with: 
+On older Ubuntu releases a symlink may be missing:
+
 {% highlight bash %}
-ln -s /etc/profile.d/vte-2.91.sh /etc/profile.d/vte.sh
+sudo ln -s /etc/profile.d/vte-2.91.sh /etc/profile.d/vte.sh
 {% endhighlight %}
-If you use a custom `PROMPT_COMMAND` instead of simply overriding `PS1` you also
-need to update your `PROMPT_COMMAND` to append working directory information.
-This can be achieved by calling `__vte_osc7` which gets defined when you source
-`/etc/profile.d/vte-2.91.sh`.
+
+If you use a custom `PROMPT_COMMAND` instead of simply overriding `PS1`, your `PROMPT_COMMAND` needs to append working-directory information. Calling `__vte_osc7` (defined by `vte-2.91.sh`) does this:
 
 {% highlight bash %}
 function custom_prompt() {
@@ -51,8 +59,8 @@ function custom_prompt() {
 PROMPT_COMMAND=custom_prompt
 {% endhighlight %}
 
-##### 2. OR use a login shell
+### Option 3 — Run the shell as a login shell
 
-Enable the option in your ttyx_ Profile (under Preferences) to use a login shell, the screenshot below shows the option that needs to be checked.
+Enable **Preferences → Profile → Command → Run command as login shell**. Login shells run `/etc/profile.d/*` scripts on any distribution, so this fixes the issue at the cost of running your full login environment every time you open a terminal.
 
-![Profile - Command]({{ site.baseurl }}/assets/images/manual/login_shell_preference.png)
+![Profile preferences showing the Run command as login shell option]({{ site.baseurl }}/assets/images/manual/login_shell_preference.png)


### PR DESCRIPTION
Refs #62. Eighth PR in the Tier B documentation pass. Finishes the manual content verification started in #69.

## Real content fixes

### `margin.md`

**Version reference was wrong.** The page claimed "available as of ttyx_ 1.8.1". There is no ttyx_ 1.8.1 — 1.8.x is a **Tilix** version that slipped through the product-name rename. Replaced with the actual GSettings keys + defaults (`draw-margin` = 80, `terminal-toggle-margin` = `<Ctrl><Alt>m`).

### `vteconfig.md`

**Missing option.** The page documented only the `vte.sh` path. ttyx_ ships its own integration script `/usr/share/ttyx/scripts/ttyx_int.sh` that does the same job via OSC 7 — now documented as the recommended Option 1.

**Stale env var.** The fallback snippet checked `$TILIX_ID`. Updated to check `$TTYX_ID` first (still falls back to `$TILIX_ID` for users mid-migration).

**Stale Fedora note.** The "Fedora patched VTE that provides notification support" note was a Tilix-era concern that no longer applies to modern VTE. Removed.

### `profileswitch.md`

**Stale "patched VTE" cross-reference.** Triggers no longer require a patched VTE (corrected on the Triggers page in #69); this page's reference was consistent with the old state. Updated to match.

**Remote configuration restructured** with the two real options (bundled `ttyx_int.sh` / trigger against prompt) and a cross-link to the Triggers example.

### `cliactions.md`

**Deprecated example.** The original example used `yaourt`, which was discontinued years ago. Replaced with `yay`.

**Missing gotchas section.** The "actions run against the focused terminal of the running instance, not the terminal where the command was invoked" behavior is non-obvious and easy to trip on. Now documented.

### `customlinks.md`

Originally three short paragraphs and a screenshot. Added:

- Configuration location (Preferences → Profile → Advanced → Custom Links).
- A concrete example table with three common patterns (Python tracebacks, `file:line` style, URLs).
- Image alt-text.

## Structural pass (all pages)

- Heading levels normalized from the imported `####` / `###` mix to consistent `##` / `###`.
- Image alt-text added where missing (margin, customlinks, vteconfig).
- Tables given proper Markdown formatting with header separators.

## Status after this PR

All 10 manual pages have now been verified and updated against the current ttyx_ code. Remaining Tier B work:

- PR 8 — fresh screenshots where the UI is visibly different from Tilix
- PR 9 — README trim (point README at the now-authoritative docs pages)

## Test plan

- [ ] Merge
- [ ] Wait for Pages rebuild
- [ ] Walk through all 5 pages and confirm tables render, images load, cross-links resolve
- [ ] Particularly verify:
  - `margin.md` no longer claims 1.8.1
  - `vteconfig.md` Option 1 (ttyx_int.sh) renders correctly
  - `cliactions.md` gotchas section is clearly set apart

Assisted by Claude Code.