### PR TITLE
fix: Clarify --action error message and debug-ttyx.sh interaction (#71)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,8 @@ Or use the bundled wrapper `debug-ttyx.sh`, which does all of the above plus lau
 
 ttyx_ is a GTK single-instance application (via D-Bus activation), so the wrapper kills any running `ttyx` before launching under gdb — otherwise the new process would hand off to the existing one and gdb would attach to nothing.
 
+**Gotcha — `ttyx -a <action>` doesn't work against a `debug-ttyx.sh` instance.** The wrapper adds `--new-process`, which disables GApplication's session-bus registration. As a side effect, later `ttyx -a session-add-right …` invocations can't discover the debug instance on the bus, so they fall through to creating a new window and print "No ttyx_ instance registered on the session bus…". If you're testing CLI actions, launch ttyx_ normally (without the wrapper).
+
 ## Tests
 
 ### Unit tests

--- a/debug-ttyx.sh
+++ b/debug-ttyx.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Debug launcher for ttyx_
+# Runs ttyx_ under GDB with GTK debug flags
+#
+# Usage:
+#   ./debug-ttyx.sh              # normal debug run
+#   ./debug-ttyx.sh --rebuild    # rebuild first, then debug
+#   ./debug-ttyx.sh --core       # analyze most recent core dump
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUILD_DIR="$SCRIPT_DIR/builddir"
+BINARY="$BUILD_DIR/ttyx"
+SCHEMAS_DIR="$SCRIPT_DIR/data/gsettings"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+case "${1:-}" in
+    --rebuild)
+        echo -e "${YELLOW}Rebuilding with debug symbols...${NC}"
+        ninja -C "$BUILD_DIR"
+        echo -e "${GREEN}Build complete.${NC}"
+        shift
+        ;;
+    --core)
+        echo -e "${YELLOW}Opening most recent ttyx_ core dump...${NC}"
+        coredumpctl debug ttyx
+        exit $?
+        ;;
+esac
+
+if [ ! -f "$BINARY" ]; then
+    echo -e "${RED}Binary not found at $BINARY${NC}"
+    echo "Run: meson setup builddir && ninja -C builddir"
+    exit 1
+fi
+
+# Kill any running ttyx_ instance (GTK single-instance via D-Bus)
+if pgrep -x ttyx > /dev/null 2>&1; then
+    echo -e "${YELLOW}Killing existing ttyx_ instance (GTK single-instance mode)...${NC}"
+    killall ttyx 2>/dev/null || true
+    sleep 1
+fi
+
+# Compile schemas so our dev settings work
+if [ -d "$SCHEMAS_DIR" ]; then
+    echo -e "${YELLOW}Compiling GSettings schemas...${NC}"
+    glib-compile-schemas "$SCHEMAS_DIR"
+    export GSETTINGS_SCHEMA_DIR="$SCHEMAS_DIR"
+fi
+
+# Make the build directory's gresource findable via XDG_DATA_DIRS.
+# The app searches for ttyx/resources/ttyx.gresource under each XDG data dir.
+# We create a symlink so that $BUILD_DIR/data/ttyx/resources/ttyx.gresource
+# points to the compiled gresource at $BUILD_DIR/data/ttyx.gresource.
+RESOURCE_LINK_DIR="$BUILD_DIR/data/ttyx/resources"
+mkdir -p "$RESOURCE_LINK_DIR"
+ln -sf "$BUILD_DIR/data/ttyx.gresource" "$RESOURCE_LINK_DIR/ttyx.gresource"
+export XDG_DATA_DIRS="$BUILD_DIR/data:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+
+# Enable core dumps for this session
+ulimit -c unlimited 2>/dev/null || true
+
+echo -e "${GREEN}Launching ttyx_ under GDB...${NC}"
+echo ""
+echo -e "  ${YELLOW}Useful GDB commands:${NC}"
+echo "    run              - start ttyx_"
+echo "    bt               - backtrace after crash"
+echo "    bt full          - backtrace with local variables"
+echo "    info threads     - list all threads"
+echo "    thread N         - switch to thread N"
+echo "    continue         - resume after a breakpoint"
+echo "    quit             - exit GDB"
+echo ""
+
+# G_DEBUG options:
+#   fatal-criticals — turn GTK CRITICAL warnings into crashes (catches bugs early)
+#   fatal-warnings  — even stricter, all GLib warnings become fatal
+#
+# Note: fatal-criticals catches real bugs but also harmless VTE/GTK
+# internal warnings we can't fix (e.g., VTE scrolling on unmapped tabs).
+# Disabled by default. Uncomment to enable for focused debugging:
+# export G_DEBUG=fatal-criticals
+
+# --new-process disables GApplication session-bus registration so we get a
+# fresh instance under gdb. Tradeoff: `ttyx -a <action>` invocations from
+# a shell cannot discover this instance and will print "No ttyx_ instance
+# registered on the session bus...". Launch ttyx_ without this wrapper if
+# you need to test CLI actions. See CONTRIBUTING.md > Using debug-ttyx.sh.
+exec gdb \
+    -ex "set print pretty on" \
+    -ex "set pagination off" \
+    -ex "set confirm off" \
+    -ex "handle SIG32 nostop noprint pass" \
+    -ex "handle SIG33 nostop noprint pass" \
+    -ex "handle SIG34 nostop noprint pass" \
+    -ex "handle SIG35 nostop noprint pass" \
+    -ex "handle SIGPIPE nostop noprint pass" \
+    --args "$BINARY" --new-process "$@"

--- a/source/gx/tilix/cmdparams.d
+++ b/source/gx/tilix/cmdparams.d
@@ -190,7 +190,11 @@ public:
         _terminalUUID = getValue(vd, CMD_TERMINAL_UUID, vts);
         if (_action.length > 0) {
             if (!acl.getIsRemote()) {
-                writeln(_("You can only use the action parameter within ttyx_"));
+                // Fired when no primary ttyx_ is registered on the session bus.
+                // Typical cause: the running instance was launched with
+                // --new-process (which disables GApplication bus registration),
+                // so secondary invocations can't find it to forward the action.
+                writeln(_("No ttyx_ instance registered on the session bus to receive the action. (Instances started with --new-process are not bus-registered.)"));
                 _exitCode = 2;
                 _exit = true;
                 _action.length = 0;


### PR DESCRIPTION
## Summary

Closes #71.

When `ttyx -a <action>` is invoked but no primary ttyx_ is registered on the session bus, the error read `"You can only use the action parameter within ttyx_"` — which is misleading. The real cause (the running instance was started with `--new-process` via `debug-ttyx.sh` and therefore isn't bus-registered) isn't mentioned anywhere.

The check itself is correct: the secondary invocation genuinely can't find a primary to forward the action to. Only the wording and surrounding documentation needed fixing.

## Changes

- **`source/gx/tilix/cmdparams.d`** — reword the message to name the actual cause and mention `--new-process` explicitly; add a short comment so future readers don't have to rediscover why this branch fires.
- **`CONTRIBUTING.md`** — add a *Gotcha* note under *Using `debug-ttyx.sh`* documenting that `ttyx -a <action>` won't work against a debug-ttyx.sh instance, with the workaround (launch without the wrapper).
- **`debug-ttyx.sh`** — add an explanatory comment before `exec gdb` describing the `--new-process` tradeoff and cross-referencing CONTRIBUTING.md.

Roughly 15 lines of non-behavioral changes across three files.

## Test plan

- [ ] `meson test -C builddir --print-errorlogs` passes (no logic change, but confirms the string swap didn't break anything).
- [ ] With a ttyx_ instance launched via `./debug-ttyx.sh`, run `ttyx -a session-add-right -x "less README.md"` in another shell and confirm the new error mentions `--new-process`.
- [ ] With a ttyx_ instance launched normally (no wrapper), confirm `ttyx -a session-add-right -x "less README.md"` still works and splits the active terminal as expected.

Assisted by Claude Code.