### PR TITLE
docs: Trim README against docs site (#62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build Status](https://github.com/gwelr/tilix/workflows/Build%20Test/badge.svg)
+[![Build Test](https://github.com/gwelr/ttyx_/actions/workflows/build-test.yml/badge.svg)](https://github.com/gwelr/ttyx_/actions/workflows/build-test.yml)
 
 <p align="center">
   <img src="data/hey-ttyx.svg" alt="ttyx_ logo" width="128">
@@ -8,155 +8,35 @@
 
 **Tilix, but with a pulse.**
 
-ttyx_ is an actively maintained fork of [Tilix](https://github.com/gnunn1/tilix), the tiling terminal emulator for Linux. The original project did amazing work but with development stalled and a growing list of unaddressed bugs, ttyx_ picks up where it left off.
+ttyx_ is an actively maintained fork of [Tilix](https://github.com/gnunn1/tilix), the tiling terminal emulator for Linux. The original project did amazing work, but with development stalled and a growing list of unaddressed bugs, ttyx_ picks up where it left off — with a focus on security hardening and responsiveness to modern Linux desktops.
 
-Same great terminal. Fresh fixes, new features, and someone actually reading the issues (maybe).
+📖 **[Documentation site](https://gwelr.github.io/ttyx_/)** — install, manual, security reference, migration guide, changelog.
 
-## What's new since Tilix
+## What you get
 
-- Crash fix for malformed OSC 7 URIs
-- Fix for color schemes incorrectly shown as "Custom"
-- New tabs open next to the current tab (not at the end)
-- Strip trailing whitespace on copy (optional)
-- Visual indicator when running as root
-- Fixed title bar markup rendering
-- Fixed focus stealing on terminal restart
-- Fixed proxy host protocol duplication
-- Added `~` and `@` to word-select characters
-- Preferences dialog segfault fixes
-- 8 new color schemes: Catppuccin (Latte, Mocha), Dracula, Gruvbox (Dark, Light), Nord, Solarized (Dark, Light)
-- Release build optimizations (proper `-O3` and `-release` flags)
-- Comprehensive unit test suite (119 tests)
-- **Security hardening** (see below)
+- **Tiling terminal** — split horizontally, vertically, nest arbitrarily. Drag and drop between windows. Save and restore layouts as sessions. Synchronized input across terminals.
+- **Security-conscious by default** — paste review with dangerous-command detection, clipboard auto-clear, root/SSH visual indicators, core-dump protection, in-memory-only scrollback, one-shortcut `Secure Clear`. Full list on the [Security features page](https://gwelr.github.io/ttyx_/security/).
+- **Actively maintained** — crash fixes, new color schemes, release-build optimizations, a growing unit-test suite. See [What's new vs Tilix](https://gwelr.github.io/ttyx_/whats-new/) for the feature-level comparison and the [changelog](https://gwelr.github.io/ttyx_/changelog/) for per-release notes.
 
-## Security features
+## Install
 
-ttyx_ is designed to be a security-conscious terminal. All security options are in **Preferences > Advanced > Security**.
+End users: grab the signed Flatpak bundle from the [latest release](https://github.com/gwelr/ttyx_/releases/latest) — the [Install page](https://gwelr.github.io/ttyx_/install/) walks through signature verification and install.
 
-### Paste protection
-Pasting content from the clipboard can be dangerous — a malicious website could place harmful commands in your clipboard. ttyx_ protects you with:
-
-- **Bracketed paste escape stripping** — silently removes `ESC[200~`/`ESC[201~` sequences that could break out of the shell's paste mode and inject commands. Always active, no option to disable.
-- **Multi-line paste review** — shows a review dialog before pasting multi-line content, letting you inspect and edit before it reaches the shell. *(Default: on)*
-- **Dangerous command detection** — flags pastes containing `sudo`, `su`, `rm -rf`, `curl | bash`, `dd if=`, `mkfs`, `chmod 777`, fork bombs, and other dangerous patterns.
-
-### Clipboard protection
-- **Auto-clear** — automatically clears the clipboard after a configurable timeout (5–300 seconds) following a copy from the terminal. Prevents sensitive data like passwords and tokens from lingering. Only clears if the clipboard still holds the content you copied (won't wipe something another app put there). *(Default: off, 30 seconds)*
-
-### Visual indicators
-- **Root indicator** — red tint and "as root" label when any process in the terminal is running with elevated privileges. *(Default: on)*
-- **SSH indicator** — blue tint and "ssh" label when connected via ssh, scp, sftp, mosh, or sshfs. *(Default: on)*
-
-### Memory protection
-- **Core dump protection** — marks the process as non-dumpable via `prctl(PR_SET_DUMPABLE, 0)`, preventing `/proc/pid/mem` reads and core dump generation. Disable in preferences if you need to attach GDB. *(Default: on)*
-- **In-memory-only scrollback** — scrollback is capped at 256–999,999 lines and kept entirely in memory. VTE never writes history to disk.
-- **Secure Clear** (`Ctrl+Shift+L`) — wipe the scrollback buffer when sensitive data has been displayed. Available in the hamburger menu and right-click context menu.
-
-## Features
-
-* Tile terminals any way you like — split horizontally, vertically, go wild
-* Drag and drop terminals within and between windows
-* Synchronized input across terminals
-* Save and restore terminal layouts
-* Custom titles, color schemes, and hyperlinks
-* Transparent backgrounds
-* [Quake-mode](https://github.com/gnunn1/tilix/wiki/Quake-Mode) (drop-down terminal)
-* Automatic profile switching based on hostname/directory
-* Trigger support and badges (with compatible VTE)
-
-## Requirements
-
-* GTK 3.18+
-* VTE 0.46+ (0.76+ recommended)
-* dconf / GSettings
-
-## Building
-
-ttyx_ is written in [D](https://dlang.org/) using GTK 3 and the GtkD bindings.
-
-### With Meson (recommended)
-
-The Meson build resolves the GtkD bindings (`gtkd-3`, `vted-3`) via
-pkg-config, so they must be installed separately. On distros that still
-package them, apt covers everything. On Debian Testing/Sid they have
-been dropped from the archive and must be built from source.
-
-```bash
-# Install dependencies (Debian Stable / Ubuntu)
-sudo apt-get install libgtk-3-dev libvte-2.91-dev libatk1.0-dev \
-  libcairo2-dev libpango1.0-dev librsvg2-dev libglib2.0-dev \
-  libsecret-1-dev libgtksourceview-3.0-dev libpeas-dev dh-dlang \
-  libgtkd-3-dev libvted-3-dev
-```
-
-```bash
-# Install dependencies (Debian Testing / Sid — libgtkd-3-dev and
-# libvted-3-dev are no longer in the archive)
-sudo apt-get install libgtk-3-dev libvte-2.91-dev libatk1.0-dev \
-  libcairo2-dev libpango1.0-dev librsvg2-dev libglib2.0-dev \
-  libsecret-1-dev libgtksourceview-3.0-dev libpeas-dev dh-dlang
-
-# Then build and install GtkD v3.x from source — the same steps CI uses
-# are in .github/ci/make-install-deps-extern.sh
-```
-
-```bash
-# Build
-meson setup builddir --buildtype=release
-ninja -C builddir
-
-# Install
-sudo ninja -C builddir install
-
-# Run tests
-meson test -C builddir --print-errorlogs
-```
-
-### With Dub
-
-```bash
-dub build --build=release --compiler=ldc2
-```
+Distro packagers and developers: the same page covers source builds with Meson (primary, matches CI) and Dub.
 
 ## Migrating from Tilix
 
-ttyx_ automatically migrates your configuration on first run:
-
-- **Session files**: `~/.config/tilix/` is copied to `~/.config/ttyx/` (the original is kept as backup)
-- **Saved passwords**: existing passwords stored under the old Tilix schema are read automatically; new passwords are saved under the ttyx schema
-- **Environment variable**: `TILIX_ID` is still set for backwards compatibility alongside the new `TTYX_ID`
-- **GSettings**: ttyx_ uses its own schema (`io.github.gwelr.ttyx`). Tilix settings are not migrated — configure preferences in ttyx_ directly
-
-After verifying ttyx_ works correctly, you can remove `~/.config/tilix/` manually.
-
-## Troubleshooting
-
-### App icon shows as a broken placeholder
-
-This typically means a stale icon cache from a previous install (often Flatpak). Clear the user-level cache and let GTK regenerate it:
-
-```bash
-rm -f ~/.local/share/flatpak/exports/share/icons/hicolor/icon-theme.cache
-gtk-update-icon-cache -f ~/.local/share/flatpak/exports/share/icons/hicolor/
-```
-
-Then relaunch ttyx_.
-
-### Quake mode doesn't position correctly (Wayland)
-
-Quake mode relies on X11 window positioning APIs that Wayland compositors don't expose to applications. On Wayland, behavior is compositor-dependent — GNOME Shell in particular cannot position windows from the application side.
-
-**Workaround**: use ttyx_ under an X11 session if you need Quake mode. On wlroots-based compositors (Sway, Hyprland), support may be added in a future release via the `wlr-layer-shell` protocol.
+ttyx_ migrates your session files and reads existing saved passwords automatically on first run; both `TTYX_ID` and `TILIX_ID` are set so existing shell-integration scripts keep working. See [Migrating from Tilix](https://gwelr.github.io/ttyx_/migrating/) for the full checklist and rollback steps.
 
 ## Contributing
 
-This is a freetime project. I work on what interests me, when I have time.
+See [CONTRIBUTING.md](CONTRIBUTING.md) — build, run, test, debug, code style, and PR conventions.
 
-**Issues** must include: what happened, what was expected, steps to reproduce, and environment details (distro, VTE version, etc.). Incomplete issues will be closed without review.
+**Issues** must include what happened, what was expected, reproduction steps, and environment details (distro, VTE version, display server). Incomplete issues will be closed without review.
 
-**Pull requests** are the best way to get something changed. That said, PRs may be declined if they don't fit the project direction — no hard feelings. If you disagree, fork it. That's how this project started too.
+**Pull requests** are the best way to get something changed. PRs may be declined if they don't fit the project direction — no hard feelings. If you disagree, fork it. That's how this project started too.
 
-No support is provided.
+This is a freetime project. No support is provided.
 
 ## Credits
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,4 +21,4 @@ ttyx_ is a freetime project and releases are irregular. See the [GitHub Releases
 
 ## Reporting issues
 
-Bug reports belong in the [issue tracker](https://github.com/gwelr/ttyx_/issues). See the README's [Contributing](https://github.com/gwelr/ttyx_#contributing) section for what a complete bug report should include.
+Bug reports belong in the [issue tracker](https://github.com/gwelr/ttyx_/issues). See [CONTRIBUTING.md](https://github.com/gwelr/ttyx_/blob/master/CONTRIBUTING.md) for what a complete bug report should include.

--- a/docs/install.md
+++ b/docs/install.md
@@ -125,4 +125,17 @@ On first run:
 
 ## Troubleshooting
 
-If the app icon appears as a broken placeholder after a Flatpak install, the likely cause is a stale icon cache. See the [Troubleshooting section in the README](https://github.com/gwelr/ttyx_#troubleshooting) for the one-line fix and for Wayland Quake-mode notes.
+### App icon shows as a broken placeholder
+
+Typically a stale icon cache from a previous install. Clear the user-level cache and let GTK regenerate it:
+
+```bash
+rm -f ~/.local/share/flatpak/exports/share/icons/hicolor/icon-theme.cache
+gtk-update-icon-cache -f ~/.local/share/flatpak/exports/share/icons/hicolor/
+```
+
+Then relaunch ttyx_.
+
+### Quake mode doesn't position correctly on Wayland
+
+See the [Wayland section on the Quake manual page]({{ site.baseurl }}/manual/quake/#wayland) for compositor-specific notes and workarounds.

--- a/docs/manual/quake.md
+++ b/docs/manual/quake.md
@@ -25,7 +25,7 @@ Open GNOME's Keyboard settings and add a custom shortcut matching the screenshot
 
 ## Wayland
 
-Quake mode relies on X11 window-positioning APIs that Wayland compositors don't expose to applications, so behaviour is compositor-dependent. GNOME Shell in particular cannot position windows from the application side. See the [README's Troubleshooting section](https://github.com/gwelr/ttyx_#quake-mode-doesnt-position-correctly-wayland) for the current state.
+Quake mode relies on X11 window-positioning APIs that Wayland compositors don't expose to applications, so behaviour is compositor-dependent. GNOME Shell in particular cannot position windows from the application side.
 
 Two workarounds:
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -86,4 +86,4 @@ Upstream Tilix development stalled with known issues unresolved. ttyx_ ships fix
 - Shells inside terminals get both `TTYX_ID` and `TILIX_ID` set, so existing shell-integration scripts continue to work.
 - On first run, `~/.config/tilix/` is copied to `~/.config/ttyx/`; the original is left in place as a backup.
 
-See [Migrating from Tilix](https://github.com/gwelr/ttyx_#migrating-from-tilix) for the full migration checklist.
+See [Migrating from Tilix]({{ site.baseurl }}/migrating/) for the full migration checklist.


### PR DESCRIPTION
## Summary

Refs #62. Closes the **PR 9 — README trim** item on the Tier B umbrella.

The README duplicated material already maintained on the docs site (install, security features, what's-new, migration, troubleshooting). Duplicated content drifts — the docs site is the authoritative source for each topic, so the README becomes a landing page that points at it.

README shrinks from 167 lines to ~50.

## README changes

- **What's new since Tilix** bullet list → one-sentence *Actively maintained* teaser linking to `/whats-new/` and `/changelog/`.
- **Security features** section → one-sentence teaser linking to `/security/`.
- **Building** (Meson/Dub/deps) → pointer to the Install page for both end-user Flatpak and source builds.
- **Migrating from Tilix** section → one-paragraph teaser linking to `/migrating/`.
- **Troubleshooting** section → removed; the Flatpak icon-cache fix moves into `docs/install.md` where it belongs, and the Wayland Quake note now links straight to the Wayland section of the Quake manual page.
- **Contributing** section body → pointer to CONTRIBUTING.md (which now carries the dev-workflow content), keeping the repo-level *issues must include…* and *PRs may be declined* paragraphs.
- **Features** and **Requirements** → collapsed into a single *tiling terminal* teaser bullet plus the documentation-site link at the top.
- **CI badge URL** — badge pointed at `gwelr/tilix` (stale repo name) and used the deprecated workflow-name path; switched to `gwelr/ttyx_` + `/actions/workflows/build-test.yml` (verified 200).

## Docs back-reference fixes

Four pages on the docs site anchored into README sections that no longer exist. Repointed them to the authoritative places:

- `docs/whats-new.md` — "Migrating from Tilix" → `/migrating/`.
- `docs/changelog.md` — bug-report guidance → CONTRIBUTING.md.
- `docs/install.md` — inline the Flatpak icon-cache fix (previously a pointer back to `README#troubleshooting`); Wayland Quake note → `/manual/quake/#wayland`.
- `docs/manual/quake.md` — drop the "See the README's Troubleshooting section" sentence; the page's own Wayland section already covers everything.

## Merge-order note

This PR and #74 (screenshot removal) both touch `docs/manual/quake.md` in different sections, so they should auto-merge regardless of order. If a trivial rebase is needed on whichever lands second, it's a one-line conflict at worst.

## Test plan

- [ ] GitHub renders the new README correctly on the repo landing page.
- [ ] CI badge renders (not a broken-image placeholder).
- [ ] Jekyll build succeeds; visit `/install/`, `/migrating/`, `/security/`, `/whats-new/`, `/changelog/`, `/manual/quake/` on the preview and confirm all links resolve.
- [ ] `grep -rE 'github\.com/gwelr/ttyx_#|README\.md#|README#' docs/` returns no hits.

Assisted by Claude Code.