### PR TITLE
fix: Avoid std.logger call in ProcessMonitor destructor (#72)

### DIFF
--- a/source/gx/tilix/terminal/monitor.d
+++ b/source/gx/tilix/terminal/monitor.d
@@ -84,7 +84,12 @@ public:
     }
 
     ~this() {
-        stop();
+        // Intentionally empty. stop() calls trace() via std.logger, which
+        // synchronizes on an Object monitor. When ~this() fires during GC
+        // termination (rt_term), the monitor subsystem has already been
+        // torn down and _d_monitorenter segfaults in rt.monitor_.ensureMonitor.
+        // The spawned worker thread is reaped by the D runtime's thread
+        // cleanup on process exit, so there's nothing useful left to do here.
     }
 
     void start() {
@@ -95,7 +100,8 @@ public:
     }
 
     void stop() {
-        if (running) tid.send(true);
+        if (!running) return;
+        tid.send(true);
         running = false;
         trace("Stopped process monitoring");
     }


### PR DESCRIPTION
## Summary

Closes #72.

ttyx_ segfaulted in `rt_term` when the process exited after launching a `-x` command that failed to spawn (e.g. `ttyx -x yay-not-installed`). The crash was only *visible* when ttyx was launched from a shell that reaps the child's exit status — closing a normal ttyx window via the X button hid the same segfault because nothing was reading the exit code.

## Root cause

`ProcessMonitor.~this()` called `stop()`, which logs via `std.logger`'s `trace()`. The logger synchronizes on an `Object` monitor, and by the time `~this()` fires during GC finalization at program termination, `rt_term` has already torn down the monitor subsystem. `_d_monitorenter` → `rt.monitor_.ensureMonitor` then segfaults when asked to lazily allocate a monitor for a logger whose backing storage is gone.

### gdb backtrace (thread 1)

```
#0 rt.monitor_.ensureMonitor
#1 _d_monitorenter
#2 std.logger.core.Logger.memLogFunctions.logImpl
#3 std.logger.core.defaultLogFunction
#4 ProcessMonitor.stop()                  ← trace("Stopped process monitoring")
#5 ProcessMonitor.~this()                 ← finalizer
#6 rt_finalize2 → Gcx.sweep → gc_term → rt_term
```

## Fix

1. **`~this()` is now a no-op**, with a comment explaining why. The spawned worker thread is cleaned up by the D runtime's thread-join on process exit — there is nothing useful left to do in the destructor, and logging from it is categorically unsafe.
2. **`stop()` is idempotent** — short-circuits when `!running`. Before, `stop()` guarded only the `tid.send()` call but still ran `trace()` unconditionally; that's the nit the crash made visible, and it's the right behaviour for a "stop" call anyway.

Runtime behaviour is unchanged: `removeProcess()` still calls `stop()` under `running == true`, so the trace message fires once when the monitor genuinely stops, as before. The only path that now skips the trace is the already-dead `~this()` path, which was already unreliable and now simply does nothing.

## Why this only surfaced via `-x` failures

Every ttyx_ exit path triggers the same segfault during `rt_term`, not just the failed-spawn case. But a SIGSEGV at process-termination time is invisible unless something is reading the exit status:

- Closing via the X button → window-manager reaps the process, nothing cares about exit 139.
- `ttyx -x <bad-cmd>` from a shell → bash reaps the child, sees exit 139, prints "Segmentation fault".

So this bug has almost certainly been latent across *all* ttyx_ (and likely Tilix) exits — only the `-x` failure path made it user-visible.

## Test plan

- [x] Unit test suite passes (`meson test -C builddir --print-errorlogs`).
- [x] `ttyx --new-process -x "nonexistent-cmd"` launched under gdb on X11, closed via `xdotool windowclose`: before this commit, SIGSEGV at `monitor.d:100` with the stack trace above; after this commit, exits cleanly with code 0 and no crash.
- [x] Manual smoke: open a normal ttyx_ window, split a few terminals, close each one, close the window. Confirm no new CRITICAL warnings beyond what was there before.
- [x] Manual: launch a long-running process in a terminal, exit it, confirm the "Stopped process monitoring" trace still appears in the log at the runtime boundary (not the rt_term one).

Assisted by Claude Code.