### PR TITLE
ops: Add memory baseline and CI GC profiling

### DIFF
--- a/.github/ci/measure-memory.sh
+++ b/.github/ci/measure-memory.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Measure RSS memory footprint of ttyx at startup.
+# Runs inside the CI container after a meson build.
+# Always exits 0 — this step is informational, not a gate.
+
+set -e
+
+BUILD_DIR="cibuild"
+SCHEMA_DIR="data/gsettings"
+
+# Compile GSettings schemas from source tree
+glib-compile-schemas "$SCHEMA_DIR"
+
+# Create the gresource symlink that ttyx expects under XDG_DATA_DIRS
+mkdir -p "$BUILD_DIR/data/ttyx/resources"
+ln -sf "$(pwd)/$BUILD_DIR/data/ttyx.gresource" \
+       "$BUILD_DIR/data/ttyx/resources/ttyx.gresource"
+
+# Start a virtual display
+Xvfb :99 -screen 0 1024x768x24 &
+XVFB_PID=$!
+sleep 1
+
+# Launch ttyx with:
+#   --new-process    skip D-Bus session registration (no session bus in CI)
+#   GSETTINGS_BACKEND=memory  bypass dconf (no D-Bus needed for settings)
+DISPLAY=:99 \
+GSETTINGS_BACKEND=memory \
+GSETTINGS_SCHEMA_DIR="$(pwd)/$SCHEMA_DIR" \
+XDG_DATA_DIRS="$(pwd)/$BUILD_DIR/data:/usr/local/share:/usr/share" \
+"./$BUILD_DIR/ttyx" --new-process &
+TTYX_PID=$!
+
+# Give the GTK app time to fully initialise
+sleep 6
+
+if kill -0 "$TTYX_PID" 2>/dev/null; then
+    RSS=$(ps -o rss= -p "$TTYX_PID" | tr -d ' ')
+    MB=$(( ${RSS:-0} / 1024 ))
+    echo "RSS at startup: ${MB} MB (${RSS} KB)"
+    kill "$TTYX_PID" 2>/dev/null || true
+    wait "$TTYX_PID" 2>/dev/null || true
+else
+    echo "WARNING: ttyx exited before RSS could be measured (check logs above)"
+fi
+
+kill "$XVFB_PID" 2>/dev/null || true
+wait "$XVFB_PID" 2>/dev/null || true
+
+exit 0

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -70,6 +70,11 @@ jobs:
       run: podman run -t -e COMPILER_VENDOR=$CVENDOR -e CC=gcc -e CXX=g++ -v `pwd`:/build ttyx
            ./.github/ci/run-tests.sh
 
+    - name: Memory Footprint
+      continue-on-error: true
+      run: podman run -t -e CC=gcc -e CXX=g++ -v `pwd`:/build ttyx
+           ./.github/ci/measure-memory.sh
+
 
   build-dub-ubuntu:
     name: Dub
@@ -108,3 +113,10 @@ jobs:
 
     - name: Test
       run: xvfb-run dub test --compiler=$DC
+
+    - name: GC Profile
+      run: |
+        OUTPUT=$(xvfb-run dub test --compiler=$DC -- --DRT-gcopt=profile:1 2>&1)
+        GC_LINE=$(echo "$OUTPUT" | grep "GC summary" || echo "GC summary: not available")
+        echo "### GC profile (${{ matrix.dc }})" >> "$GITHUB_STEP_SUMMARY"
+        printf '```\n%s\n```\n' "$GC_LINE" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/memory-baseline.md
+++ b/docs/memory-baseline.md
@@ -1,0 +1,89 @@
+---
+title: Memory baseline
+layout: default
+nav_order: 99
+permalink: /memory-baseline/
+---
+
+# Memory baseline
+
+This page records ttyx_'s memory footprint and GC allocation profile as of each
+measurement. Use it to detect regressions: if the numbers climb significantly
+between releases, investigate before shipping.
+
+## How to read this
+
+| Metric | What it tells you |
+|---|---|
+| **RSS at startup** | Resident set size after the app finishes initialising (one terminal, idle). Includes GTK, VTE, and all shared-library pages that are resident. |
+| **GC summary (unit tests)** | D garbage-collector stats at the end of the full `dub test` run. Shows total D heap used and how often the GC had to collect. |
+
+A large jump in RSS (> 20 MB between releases) warrants a look at new GTK
+widget allocations or unreleased object references. A large jump in GC heap
+(> 2× without a known feature addition) suggests an unintentional reference
+keeping objects alive.
+
+## Current baseline
+
+Measured on 2026-04-23, commit `523597d2`, Debian Trixie, LDC 1.36.0.
+
+### RSS at startup
+
+| Configuration | RSS |
+|---|---|
+| One terminal, idle, `--new-process` flag | **72 MB** |
+
+### GC profile (unit tests)
+
+```
+GC summary:    5 MB,    2 GC    0 ms, Pauses    0 ms <    0 ms
+```
+
+Collected twice during 29 test modules. Total D heap at exit: 5 MB.
+GC pause time is negligible.
+
+## How to re-measure locally
+
+### RSS
+
+```bash
+# Build first (system ldc2, meson):
+meson setup builddir --wipe && ninja -C builddir
+
+# Then launch and measure:
+glib-compile-schemas data/gsettings/
+mkdir -p builddir/data/ttyx/resources
+ln -sf "$(pwd)/builddir/data/ttyx.gresource" builddir/data/ttyx/resources/ttyx.gresource
+
+Xvfb :98 -screen 0 1024x768x24 &
+DISPLAY=:98 \
+GSETTINGS_BACKEND=memory \
+GSETTINGS_SCHEMA_DIR=$(pwd)/data/gsettings/ \
+XDG_DATA_DIRS=$(pwd)/builddir/data:/usr/local/share:/usr/share \
+./builddir/ttyx --new-process &
+TTYX_PID=$!
+sleep 6
+ps -o pid=,rss= -p $TTYX_PID
+kill $TTYX_PID
+```
+
+For a realistic multi-terminal session, use `monitor-rss.sh` instead:
+```bash
+./monitor-rss.sh 60   # sample every 60 seconds
+```
+
+### GC profile
+
+```bash
+export PATH="/path/to/ldc/bin:$PATH"
+dub test -- --DRT-gcopt=profile:1 2>&1 | grep "GC summary"
+```
+
+## CI integration
+
+The **Ubuntu LTS** CI job runs `measure-memory.sh` after the test suite on every
+PR. Results appear in the GitHub Actions job summary. The step is
+`continue-on-error: true` — it never blocks a merge, it only reports.
+
+The **Dub** CI job runs `dub test` with `--DRT-gcopt=profile:1` on both DMD and
+LDC and writes the GC summary line to the job summary.


### PR DESCRIPTION
## Summary

- **GC profiling on every PR** — the Dub CI job (DMD + LDC) now runs `dub test` with `--DRT-gcopt=profile:1` and writes the GC summary line to the GitHub Actions job summary. Tracks D heap size and collection count with zero extra dependencies.
- **RSS measurement in Ubuntu LTS job** — new `measure-memory.sh` step launches the meson-built `ttyx` binary under Xvfb with `GSETTINGS_BACKEND=memory` (avoids D-Bus requirement in CI), waits for GTK init, then reads RSS via `ps`. Always `continue-on-error: true` — informational only, never blocks a merge.
- **`docs/memory-baseline.md`** — documents the current numbers (72 MB RSS at startup, 5 MB GC heap across 29 test modules) and instructions for re-measuring locally.

## Current baseline (2026-04-23, commit 523597d2)

| Metric | Value |
|---|---|
| RSS at startup (one terminal, idle) | **72 MB** |
| GC heap after unit tests | **5 MB** |
| GC collections during unit tests | **2** |
| GC pause time | **0 ms** |

## Test plan

- [x] GC profiling verified locally: `dub test -- --DRT-gcopt=profile:1` outputs `GC summary: 5 MB, 2 GC 0 ms`
- [x] RSS measurement verified locally with Xvfb: 72 MB
- [x] CI run to confirm both steps appear in job summary
