### PR TITLE
fix: Robust /proc/[pid]/stat parser with bounds validation

### DIFF
--- a/source/gx/ttyx/terminal/activeprocess.d
+++ b/source/gx/ttyx/terminal/activeprocess.d
@@ -46,14 +46,33 @@ class Process {
     string[] parseStatFile() {
         try {
             string data = to!string(cast(char[])read(format("/proc/%d/stat", pid)));
-            size_t rpar = data.lastIndexOf(")");
-            string name = data[data.indexOf("(") + 1..rpar];
-            string[] other  = data[rpar + 2..data.length].split;
-            return name ~ other;
-        } catch (FileException fe) {
-            warning(fe);
-            }
+            string[] parsed = parseStatData(data);
+            if (parsed !is null) return parsed;
+            warningf("Malformed /proc/%d/stat (len=%s)", pid, data.length);
+        } catch (Exception e) {
+            // FileException from read() (process exited / not accessible),
+            // plus any future to!*-derived ConvException. RangeError from
+            // out-of-bounds slicing is prevented by parseStatData's checks.
+            warning(e);
+        }
         return "? 0 0 0 0 0 0".split;
+    }
+
+    /**
+    * Parse a /proc/[pid]/stat line into [name, field3, field4, ...].
+    * Returns null if the buffer is malformed (truncated read, missing
+    * parentheses, or wrong order). Pure function — no I/O — so callers
+    * can unit-test it with synthetic input.
+    */
+    package static string[] parseStatData(string data) {
+        size_t lpar = data.indexOf("(");
+        size_t rpar = data.lastIndexOf(")");
+        if (lpar == -1 || rpar == -1 || lpar >= rpar || rpar + 2 > data.length) {
+            return null;
+        }
+        string name = data[lpar + 1 .. rpar];
+        string[] other = data[rpar + 2 .. $].split;
+        return name ~ other;
     }
 
     /**
@@ -264,4 +283,42 @@ unittest {
     // the wiring against init (pid 1), which always runs as root.
     auto p = new Process(1);
     assert(p.isRoot());
+}
+
+unittest {
+    // parseStatData: well-formed line splits cleanly.
+    string[] r = Process.parseStatData("123 (bash) S 100 123 123 34816 200 0 0");
+    assert(r !is null);
+    assert(r[0] == "bash");
+    assert(r[1] == "S");
+    assert(r[2] == "100");
+}
+
+unittest {
+    // parseStatData: name containing ')' — lastIndexOf finds the right paren.
+    string[] r = Process.parseStatData("123 (weird )name) S 100 123");
+    assert(r !is null);
+    assert(r[0] == "weird )name");
+    assert(r[1] == "S");
+}
+
+unittest {
+    // parseStatData: malformed inputs return null instead of crashing.
+    assert(Process.parseStatData("") is null);                // empty
+    assert(Process.parseStatData("123 bash S 100") is null);  // no parens
+    assert(Process.parseStatData("123 (bash") is null);       // no rpar
+    assert(Process.parseStatData("123 bash) S") is null);     // no lpar
+    assert(Process.parseStatData("123 )bash( S") is null);    // lpar > rpar
+    assert(Process.parseStatData("123 (bash)") is null);      // truncated after rpar
+    assert(Process.parseStatData("123 (bash))") is null);     // only 1 char after rpar
+}
+
+unittest {
+    // parseStatFile fallback: non-existent PID returns the sentinel array
+    // so the rest of Process keeps working without crashing.
+    auto p = new Process(999_999_999);
+    assert(p.processStat.length >= 7);
+    assert(p.processStat[0] == "?");
+    assert(!p.hasTTY());          // sentinel field 5 is "0" → false
+    assert(!p.isForeground());    // pidExists() is false → false
 }


### PR DESCRIPTION
## Summary

Closes item 2 of #52.

`Process.parseStatFile` only caught `FileException`, leaving two failure modes exposed when a process exits between `Process.pidExists()` and the `/proc/<pid>/stat` read:

- A truncated or malformed buffer made `data[rpar + 2 .. $]` slice out of bounds, throwing `RangeError`. Since `RangeError` is an `Error` (not an `Exception`), no widening of the catch could cover it — the slice has to be guarded explicitly.
- Future `to!*`-derived `ConvException` would propagate past the old `catch(FileException)` block.

The fix extracts the pure parsing logic into a `package static` helper `parseStatData(string)` that validates `(`, `)`, ordering, and `rpar + 2 ≤ length` before slicing. `parseStatFile` calls it and falls back to the existing `"? 0 0 0 0 0 0"` sentinel when `null` is returned, preserving the graceful-degradation contract that `hasTTY`/`isForeground`/`sessionID`/`name` rely on. Catch broadened from `FileException` to `Exception` as future-proofing.

## Test plan

- [x] `meson test -C builddir --print-errorlogs` — all 3 tests pass, including 4 new unittest blocks in `activeprocess.d`:
  - well-formed `(bash)` line
  - name containing `)` (lastIndexOf finds the right paren)
  - 6 malformed-input shapes: empty, no parens, missing rpar, missing lpar, `lpar > rpar`, truncated after rpar, only 1 char after rpar
  - non-existent-PID roundtrip through `Process.this()` confirming the sentinel keeps the API working
- [x] Clean build with `ldc2`
- [ ] CI green on PR