### PR TITLE
docs: Warn users that triggers and custom links execute shell commands

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -114,6 +114,33 @@ Resets the terminal and wipes the scrollback buffer on demand. Available from th
 
 The reset is the VTE reset sequence (equivalent to `reset`), followed by an explicit scrollback-buffer clear. No part of the previous buffer is recoverable from userland after Secure Clear; a privileged attacker with kernel-level access is still out of scope.
 
+## Triggers and custom links — shell injection from terminal output
+
+ttyx_ supports two user-configurable features that turn terminal content into shell commands:
+
+- **Triggers** (Profile preferences → Advanced) — regular expressions that match against terminal output. The `ExecuteCommand` and `RunProcess` actions run a shell command using a template like `notify-send "Build failed" "$1"`, where `$1` is substituted with a regex capture group.
+- **Custom links** (Preferences → Advanced) — clickable regex matches whose template runs through `spawnShell` when the user clicks them.
+
+In both cases the substituted text comes from terminal output. **Under SSH or any remote session, terminal output is attacker-controlled.** A malicious remote host that knows you have a trigger like `^Build failed: (.+)$` → `notify-send "Build failed" "$1"` can emit:
+
+```
+Build failed: oops"; rm -rf ~/Documents; #
+```
+
+After substitution, `spawnShell` receives `notify-send "Build failed" "oops"; rm -rf ~/Documents; #"` — three commands, the second one destructive. This is the same class of bug that has affected iTerm2, tmux `-CC` mode, and various OSC 8 implementations.
+
+### Status
+
+- ttyx_ ships with **no default triggers and no default custom links**. The attack surface is exactly what you opt into.
+- The trigger and custom-link editor dialogs surface the warning at the point of editing.
+- ttyx_ does **not** currently shell-quote match-group substitutions. Designing a safe-substitution scheme that doesn't break legitimate templates (where the user intentionally wants `$1` to expand into multiple shell tokens) is open work.
+
+### Recommendations
+
+- Only enable trigger `ExecuteCommand`/`RunProcess` and custom-link templates for hosts you trust.
+- Avoid templates where a regex capture group lands in a shell-interpreted position. Prefer templates that pass the captured value to a program via a non-shell channel — for example, by setting an env var rather than embedding `$1` in a shell command string. (Subject to change once safe-substitution lands.)
+- Audit any imported trigger configurations the same way you would audit a shell script.
+
 ## Log hygiene
 
 ttyx_ writes debug logs only when file logging is explicitly compiled in (`USE_FILE_LOGGING`, default off). Even so, when logging is enabled:

--- a/source/gx/ttyx/prefeditor/advdialog.d
+++ b/source/gx/ttyx/prefeditor/advdialog.d
@@ -59,6 +59,11 @@ private:
     void createUI(string[] links) {
 
         setAllMargins(getContentArea(), 18);
+        getContentArea().add(createSecurityWarningLabel(
+            _("Warning: clicked links execute shell commands with captured text "
+            ~ "substituted in. Under SSH or any remote session that text is "
+            ~ "attacker-controlled — review templates for unquoted match-group "
+            ~ "substitutions and only configure custom links for hosts you trust.")));
         Box box = new Box(Orientation.VERTICAL, 6);
 
         ls = new ListStore([GType.STRING, GType.STRING, GType.BOOLEAN]);
@@ -231,6 +236,11 @@ private:
         string[] triggers = gs.getStrv(SETTINGS_ALL_TRIGGERS_KEY);
 
         setAllMargins(getContentArea(), 18);
+        getContentArea().add(createSecurityWarningLabel(
+            _("Warning: ExecuteCommand and RunProcess actions run shell commands "
+            ~ "with captured groups substituted in. Under SSH or any remote session "
+            ~ "terminal output is attacker-controlled — only configure these actions "
+            ~ "for hosts you trust.")));
         Box box = new Box(Orientation.HORIZONTAL, 6);
 
         ls = new ListStore([GType.STRING, GType.STRING, GType.STRING]);
@@ -387,6 +397,16 @@ Label createErrorLabel() {
     lblErrors.setNoShowAll(true);
 
     return lblErrors;
+}
+
+Label createSecurityWarningLabel(string text) {
+    Label lbl = new Label(text);
+    lbl.setHalign(GtkAlign.START);
+    lbl.setMarginBottom(12);
+    lbl.setLineWrap(true);
+    lbl.setMaxWidthChars(70);
+    lbl.setXalign(0.0);
+    return lbl;
 }
 
 bool validateRegex(ListStore ls, int regexColumn, Label lblErrors) {

--- a/source/gx/ttyx/prefeditor/common.d
+++ b/source/gx/ttyx/prefeditor/common.d
@@ -40,7 +40,7 @@ void createAdvancedUI(Grid grid, ref uint row, GSettings delegate() scb, bool sh
     grid.attach(lblCustomLinks, 0, row, 3, 1);
     row++;
 
-    string customLinksDescription = _("A list of user defined links that can be clicked on in the terminal based on regular expression definitions.");
+    string customLinksDescription = _("A list of user defined links that can be clicked on in the terminal based on regular expression definitions. Warning: clicked links execute shell commands with captured text substituted in. Under SSH or any remote session that text is attacker-controlled — only configure custom links for hosts you trust, and review templates for unquoted match-group substitutions.");
     grid.attach(createDescriptionLabel(customLinksDescription), 0, row, 2, 1);
 
     Button btnEditLink = new Button(_("Edit"));
@@ -71,7 +71,7 @@ void createAdvancedUI(Grid grid, ref uint row, GSettings delegate() scb, bool sh
         grid.attach(lblTriggers, 0, row, 3, 1);
         row++;
 
-        string triggersDescription = _("Triggers are regular expressions that are used to check against output text in the terminal. When a match is detected the configured action is executed.");
+        string triggersDescription = _("Triggers are regular expressions that are used to check against output text in the terminal. When a match is detected the configured action is executed. Warning: ExecuteCommand and RunProcess actions run shell commands with captured groups substituted in. Under SSH or any remote session terminal output is attacker-controlled — only configure these actions for hosts you trust.");
         grid.attach(createDescriptionLabel(triggersDescription), 0, row, 2, 1);
 
         Button btnEditTriggers = new Button(_("Edit"));


### PR DESCRIPTION
## Summary

Closes the doc-warning subset of #52 item 3.

Custom triggers (`ExecuteCommand`, `RunProcess` actions) and custom hyperlinks both run user-templated commands via `spawnShell`, with regex capture groups from terminal output substituted in via `replaceMatchTokens`. Under SSH or any remote session terminal output is attacker-controlled — a remote host that knows your template can craft output whose captures break out of the intended shell-quoted position and inject arbitrary commands. Same class as iTerm2 CVE-2017-2349 and similar.

ttyx_ ships with **no default triggers and no default custom links**, so the attack surface is exactly what users opt into. Until a safe-substitution design is decided (filed as a separate ticket), make the risk visible at the points users opt in:

- Parent descriptions on the profile-preferences Advanced page now warn that the actions execute shell commands and terminal output under SSH is attacker-controlled (`common.d`).
- A wrapping warning `Label` is shown at the top of both editor dialogs (`advdialog.d`) — same warning, surfaced at the point of authoring rules.
- New `## Triggers and custom links — shell injection from terminal output` section in `docs/security.md` covers the attack mechanics, status (no defaults ship; safe-substitution is open work), and recommendations.

No code paths change. The deeper safe-substitution design and the off-by-one bug spotted in `replaceMatchTokens` (`i - 1` underflow on `size_t`) are filed as separate tickets.

## Test plan

- [x] `meson test -C builddir --print-errorlogs` — 3/3 pass (no behavior change, just adds two `Label` widgets and edits two strings)
- [x] Clean build with `ldc2`
- [ ] Visual check: open Profile preferences → Advanced and confirm the trigger/custom-link warnings render
- [ ] Visual check: open both editor dialogs and confirm the inline warning Label appears at the top with proper wrapping
- [ ] Build the docs site locally and confirm the new security.md section renders