### PR TITLE
feat: Default enable-wide-handle to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Unit tests for the proxy URL builder, sensitive-value redaction, and process introspection helpers (#55, #56, #58).
 
 ### Changed
+- **`enable-wide-handle` now defaults to `true`** — the splitter between split terminals is now wide by default, making it easier to see and grab on dark themes and HiDPI displays. Existing users who have explicitly toggled this preference are unaffected; only fresh installs and users who never touched it pick up the new default. Set to `false` to restore the previous 1-pixel splitter (#48).
 - Extracted pure helpers out of the terminal widget module to reduce complexity and unlock testing: `pointInTriangle` → `gx.util.geometry`, `parsePairs` → `gx.util.string`, process introspection → `gx.util.proc` (#57, #58).
 - Process root detection now goes through a single `readProcStatus` helper; the `/proc/[pid]/status` parser was previously duplicated across `monitor.d` and `activeprocess.d` (#58).
 - Debug log path resolution now prefers `$XDG_RUNTIME_DIR/ttyx.log` over `/tmp/ttyx.log` when file logging is enabled (#55).

--- a/data/gsettings/io.github.gwelr.ttyx.gschema.xml
+++ b/data/gsettings/io.github.gwelr.ttyx.gschema.xml
@@ -223,9 +223,9 @@
       <description>When enabled, the terminal title bar will remain visible when only a single terminal exists in the session</description>
     </key>
     <key name="enable-wide-handle" type="b">
-      <default>false</default>
-      <summary>Whether splitters use a narrow (default) or wide handle</summary>
-      <description>If true, splitters between terminals use a wide handle. Only supported in GTK 2.16 and later.</description>
+      <default>true</default>
+      <summary>Whether splitters between terminals use a wide handle</summary>
+      <description>If true, splitters between split terminals use a wide handle that is easier to see and grab — especially on dark themes and HiDPI displays. If false, the splitters are 1 pixel wide. Defaults to true; users who prefer the narrower split can set this to false.</description>
     </key>
     <key name="auto-equalize-panes" type="b">
       <default>true</default>


### PR DESCRIPTION
Closes #48.

## Summary

The 1-pixel splitter between split terminals is hard to see on dark themes and effectively invisible on HiDPI displays. Flip the default to `true` so new installs get a visually distinct, easy-to-grab handle out of the box.

## Why this is safe for existing users

GSettings stores the user's explicit value separately from the schema default. **Anyone who has ever toggled this preference (even once) keeps their current value.** Only fresh installs and users who have never explicitly set it pick up the new default — they cannot be surprised by the change.

Users who prefer the narrow split can set it back via Preferences → Appearance, or:

```
gsettings set io.github.gwelr.ttyx.Settings enable-wide-handle false
```

## Other changes in the schema entry

- Tightened the description to explain what the wider handle actually buys (visibility, grabbability), so future readers don't have to guess from the key name.
- Dropped the obsolete "Only supported in GTK 2.16 and later" note. Inherited from upstream Tilix; GTK 2.16 predates this project's actual minimum (we require considerably more than that).

## Test plan

- [x] `meson test -C builddir --print-errorlogs` — 3/3 pass (schema validates, no behavior code path touched)
- [x] Clean build with `ldc2`
- [ ] Visual check after install: split a terminal and verify the splitter is now wide by default
- [x] CI green