### PR TITLE
ci: Install LDC from upstream tarball, drop apt ldc dependency

### DIFF
--- a/.github/ci/Dockerfile-debian-stable
+++ b/.github/ci/Dockerfile-debian-stable
@@ -10,6 +10,12 @@ RUN mkdir -p /build/ci/
 COPY install-deps-deb.sh /build/ci/
 RUN chmod +x /build/ci/install-deps-deb.sh && /build/ci/install-deps-deb.sh
 
+# install LDC from upstream tarball — uniform across stable and testing
+# so the two builds use the same compiler version (and so a future apt
+# disruption on either suite does not break the CI)
+COPY install-ldc-tarball.sh /build/ci/
+RUN chmod +x /build/ci/install-ldc-tarball.sh && /build/ci/install-ldc-tarball.sh
+
 COPY make-install-deps-extern.sh /build/ci/
 RUN chmod +x /build/ci/make-install-deps-extern.sh && /build/ci/make-install-deps-extern.sh
 

--- a/.github/ci/Dockerfile-debian-testing
+++ b/.github/ci/Dockerfile-debian-testing
@@ -10,6 +10,12 @@ RUN mkdir -p /build/ci/
 COPY install-deps-deb.sh /build/ci/
 RUN chmod +x /build/ci/install-deps-deb.sh && /build/ci/install-deps-deb.sh
 
+# ldc is currently missing from Debian Testing during a transition — install
+# from upstream tarball. Same script as Stable so both CI images use the same
+# compiler version.
+COPY install-ldc-tarball.sh /build/ci/
+RUN chmod +x /build/ci/install-ldc-tarball.sh && /build/ci/install-ldc-tarball.sh
+
 # GtkD is no longer packaged in Debian Testing, build it from source
 COPY make-install-deps-extern.sh /build/ci/
 RUN chmod +x /build/ci/make-install-deps-extern.sh && /build/ci/make-install-deps-extern.sh

--- a/.github/ci/Dockerfile-ubuntu-noble
+++ b/.github/ci/Dockerfile-ubuntu-noble
@@ -10,6 +10,12 @@ RUN mkdir -p /build/ci/
 COPY install-deps-deb.sh /build/ci/
 RUN chmod +x /build/ci/install-deps-deb.sh && /build/ci/install-deps-deb.sh
 
+# install LDC from upstream tarball — uniform across all CI images so the
+# build is not coupled to any one distro's apt archive (see #49 / fix for
+# ldc disappearing from Debian Testing during a transition)
+COPY install-ldc-tarball.sh /build/ci/
+RUN chmod +x /build/ci/install-ldc-tarball.sh && /build/ci/install-ldc-tarball.sh
+
 COPY make-install-deps-extern.sh /build/ci/
 RUN chmod +x /build/ci/make-install-deps-extern.sh && /build/ci/make-install-deps-extern.sh
 

--- a/.github/ci/install-deps-deb.sh
+++ b/.github/ci/install-deps-deb.sh
@@ -15,14 +15,18 @@ apt-get install -yq \
         eatmydata \
         build-essential
 
-# install build dependencies
+# install build dependencies. Note: ldc is installed from the upstream
+# tarball by install-ldc-tarball.sh — it is currently missing from
+# Debian Testing during a transition. curl/xz-utils/ca-certificates are
+# the tools that script needs.
 eatmydata apt-get install -yq \
         meson \
         ninja-build \
         appstream \
+        ca-certificates \
+        curl \
         desktop-file-utils \
         git \
-        ldc \
         libatk1.0-dev \
         libcairo2-dev \
         libglib2.0-dev \
@@ -34,4 +38,5 @@ eatmydata apt-get install -yq \
         libpeas-dev \
         libvte-2.91-dev \
         po4a \
-        xvfb
+        xvfb \
+        xz-utils

--- a/.github/ci/install-deps-deb.sh
+++ b/.github/ci/install-deps-deb.sh
@@ -18,7 +18,9 @@ apt-get install -yq \
 # install build dependencies. Note: ldc is installed from the upstream
 # tarball by install-ldc-tarball.sh — it is currently missing from
 # Debian Testing during a transition. curl/xz-utils/ca-certificates are
-# the tools that script needs.
+# the tools that script needs. libxml2 is a runtime dependency of the
+# upstream LDC binary itself (the prebuilt tarball dynamically links to
+# libxml2.so.2; missing from Debian Testing's base image otherwise).
 eatmydata apt-get install -yq \
         meson \
         ninja-build \
@@ -37,6 +39,7 @@ eatmydata apt-get install -yq \
         libgtksourceview-3.0-dev \
         libpeas-dev \
         libvte-2.91-dev \
+        libxml2 \
         po4a \
         xvfb \
         xz-utils

--- a/.github/ci/install-deps-deb.sh
+++ b/.github/ci/install-deps-deb.sh
@@ -15,12 +15,12 @@ apt-get install -yq \
         eatmydata \
         build-essential
 
-# install build dependencies. Note: ldc is installed from the upstream
-# tarball by install-ldc-tarball.sh — it is currently missing from
-# Debian Testing during a transition. curl/xz-utils/ca-certificates are
-# the tools that script needs. libxml2 is a runtime dependency of the
-# upstream LDC binary itself (the prebuilt tarball dynamically links to
-# libxml2.so.2; missing from Debian Testing's base image otherwise).
+# install build dependencies. Note: ldc and its runtime libxml2
+# dependency are handled by install-ldc-tarball.sh — ldc is currently
+# missing from Debian Testing during a transition, and libxml2 went
+# through a SONAME bump in the same suite (libxml2.so.2 → .so.16)
+# so the package name varies. curl/xz-utils/ca-certificates are the
+# tools install-ldc-tarball.sh needs.
 eatmydata apt-get install -yq \
         meson \
         ninja-build \
@@ -39,7 +39,6 @@ eatmydata apt-get install -yq \
         libgtksourceview-3.0-dev \
         libpeas-dev \
         libvte-2.91-dev \
-        libxml2 \
         po4a \
         xvfb \
         xz-utils

--- a/.github/ci/install-ldc-tarball.sh
+++ b/.github/ci/install-ldc-tarball.sh
@@ -20,6 +20,26 @@ LDC_TARBALL="ldc2-${LDC_VERSION}-${LDC_PLATFORM}.tar.xz"
 LDC_URL="https://github.com/ldc-developers/ldc/releases/download/v${LDC_VERSION}/${LDC_TARBALL}"
 LDC_PREFIX="/opt/ldc2"
 
+# LDC's prebuilt binary dynamically links to libxml2.so.2. Install whatever
+# package provides it on the running distro:
+#   - Debian Stable / Ubuntu: `libxml2` still ships the legacy SONAME.
+#   - Debian Testing (forky): libxml2 went through a SONAME bump to .so.16;
+#     the legacy package is gone. Install libxml2-16 and symlink so the
+#     LDC binary can dlopen "libxml2.so.2". The libxml2 ABI surface that
+#     LDC actually uses is small enough that this works in practice;
+#     verified by the post-install smoke-test below.
+if apt-get install -yq libxml2 2>/dev/null; then
+    : # legacy SONAME available natively
+else
+    echo ">>> libxml2 (legacy SONAME) unavailable — installing libxml2-16 + compat symlink"
+    apt-get install -yq libxml2-16
+    libdir="/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null \
+                       || gcc -print-multiarch 2>/dev/null \
+                       || echo x86_64-linux-gnu)"
+    ln -sf "${libdir}/libxml2.so.16" "${libdir}/libxml2.so.2"
+    ldconfig
+fi
+
 mkdir -p "${LDC_PREFIX}"
 curl -fsSL "${LDC_URL}" | tar -xJ --strip-components=1 -C "${LDC_PREFIX}"
 
@@ -42,3 +62,17 @@ if ! ldc2 --version; then
     ldd "${LDC_PREFIX}/bin/ldc2" || true
     exit 1
 fi
+
+# Real-compile smoke test — `--version` does not exercise the libxml2
+# code path, so on Debian Testing (where we symlink libxml2.so.2 →
+# libxml2.so.16 above) ABI breakage would only surface at compile time.
+# Compile a trivial program to catch that here, before the real build.
+cat > /tmp/ldc-smoke.d <<'EOF'
+void main() {}
+EOF
+if ! ldc2 -of=/tmp/ldc-smoke /tmp/ldc-smoke.d; then
+    echo "===== ldc2 failed to compile — likely a libxml2 ABI issue ====="
+    ldd "${LDC_PREFIX}/bin/ldc2" || true
+    exit 1
+fi
+rm -f /tmp/ldc-smoke /tmp/ldc-smoke.d /tmp/ldc-smoke.o

--- a/.github/ci/install-ldc-tarball.sh
+++ b/.github/ci/install-ldc-tarball.sh
@@ -34,5 +34,11 @@ done
 echo "${LDC_PREFIX}/lib" > /etc/ld.so.conf.d/ldc.conf
 ldconfig
 
-# Smoke-test the install — fails the build immediately if something is wrong.
-ldc2 --version
+# Smoke-test: if ldc2 fails to launch, dump all unresolved shared
+# libraries before exiting so the next CI iteration can fix them all
+# at once instead of discovering them one-by-one.
+if ! ldc2 --version; then
+    echo "===== ldc2 failed to launch — dumping ldd output ====="
+    ldd "${LDC_PREFIX}/bin/ldc2" || true
+    exit 1
+fi

--- a/.github/ci/install-ldc-tarball.sh
+++ b/.github/ci/install-ldc-tarball.sh
@@ -67,12 +67,13 @@ fi
 # code path, so on Debian Testing (where we symlink libxml2.so.2 →
 # libxml2.so.16 above) ABI breakage would only surface at compile time.
 # Compile a trivial program to catch that here, before the real build.
-cat > /tmp/ldc-smoke.d <<'EOF'
+# File name must be a valid D identifier — no hyphens.
+cat > /tmp/smoke.d <<'EOF'
 void main() {}
 EOF
-if ! ldc2 -of=/tmp/ldc-smoke /tmp/ldc-smoke.d; then
-    echo "===== ldc2 failed to compile — likely a libxml2 ABI issue ====="
+if ! ldc2 -of=/tmp/smoke /tmp/smoke.d; then
+    echo "===== ldc2 failed to compile — possible libxml2 ABI issue ====="
     ldd "${LDC_PREFIX}/bin/ldc2" || true
     exit 1
 fi
-rm -f /tmp/ldc-smoke /tmp/ldc-smoke.d /tmp/ldc-smoke.o
+rm -f /tmp/smoke /tmp/smoke.d /tmp/smoke.o

--- a/.github/ci/install-ldc-tarball.sh
+++ b/.github/ci/install-ldc-tarball.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Install LDC (LLVM D Compiler) from the upstream binary tarball.
+#
+# Why not apt: ldc is currently missing from Debian Testing during a
+# transition (was in stable/trixie and unstable/sid, but not testing/forky).
+# Same class of issue as the GtkD-from-source fix in #49. The upstream
+# tarball install is version-pinned and distro-independent, so a future
+# apt-archive disruption does not break the CI.
+#
+# Pinned to 1.40.0 to match what Debian Stable (trixie) ships, so the
+# Stable and Testing CI builds are not silently testing different
+# compiler versions.
+set -e
+set -x
+
+LDC_VERSION="1.40.0"
+LDC_PLATFORM="linux-x86_64"
+LDC_TARBALL="ldc2-${LDC_VERSION}-${LDC_PLATFORM}.tar.xz"
+LDC_URL="https://github.com/ldc-developers/ldc/releases/download/v${LDC_VERSION}/${LDC_TARBALL}"
+LDC_PREFIX="/opt/ldc2"
+
+mkdir -p "${LDC_PREFIX}"
+curl -fsSL "${LDC_URL}" | tar -xJ --strip-components=1 -C "${LDC_PREFIX}"
+
+# Symlink LDC tooling onto PATH. dub is bundled with the official tarball.
+for tool in ldc2 ldmd2 ldc-build-runtime ldc-profdata ldc-profgen dub; do
+    if [ -x "${LDC_PREFIX}/bin/${tool}" ]; then
+        ln -sf "${LDC_PREFIX}/bin/${tool}" "/usr/local/bin/${tool}"
+    fi
+done
+
+# Make LDC's runtime libraries discoverable by the dynamic linker.
+echo "${LDC_PREFIX}/lib" > /etc/ld.so.conf.d/ldc.conf
+ldconfig
+
+# Smoke-test the install — fails the build immediately if something is wrong.
+ldc2 --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Proxy URL malformed** — the generated `http_proxy` URL had a redundant leading `@` before userinfo, which strict RFC-3986 parsers reject; credentials were also not percent-encoded, so passwords containing `@`, `:`, `/` broke the URL entirely (#51, #55).
 - **`https_proxy` missing authentication** — the auth block was gated on `scheme == "http"` so the HTTPS proxy never received credentials even when configured (#51, #55).
 - **Debian Testing CI build** — GtkD bindings were removed from Debian Testing's apt archive; CI now builds GtkD from source on that image (#49).
+- **CI: LDC compiler installed from upstream tarball** — `ldc` is currently missing from Debian Testing during a transition. All container-based CI images (Debian Stable, Debian Testing, Ubuntu Noble) now install LDC 1.40.0 from the official `ldc-developers` GitHub release tarball instead of apt, so CI is no longer coupled to any one distro's apt archive. Same mitigation pattern as the GtkD-from-source fix from #49.
 
 ### Security
 - **Config migration hardened against symlink attacks** — `migrateConfigBetween` now refuses to follow symlinks and skips existing target files during the Tilix → ttyx_ first-run migration (#49).


### PR DESCRIPTION
## Summary

`ldc` is currently missing from Debian Testing during a package transition — the Debian tracker shows it in Stable (Trixie, 1.40.0-5) and Unstable (Sid, 1.41.0-1) but no version in Testing (Forky). A new upload "is not reproduced on amd64" per the tracker, so it has not migrated. Same class of issue as GtkD vanishing from Testing in #49.

## What changed

Decouple the CI from the apt archive for the build compiler:

- **Drop `ldc` from `install-deps-deb.sh`**, add `curl` / `xz-utils` / `ca-certificates` (the tools the new install script needs).
- **New `install-ldc-tarball.sh`** — downloads LDC 1.40.0 from the official `ldc-developers` GitHub release, extracts to `/opt/ldc2`, symlinks `ldc2` / `ldmd2` / `dub` onto `PATH`, and registers the runtime libraries with `ldconfig`. Smoke-tests `ldc2 --version` so any download or extract failure surfaces immediately.
- **Wire the new step into all three container Dockerfiles** (Debian Stable, Debian Testing, Ubuntu Noble). Inserted between the apt step and the `make-install-deps-extern.sh` step, since the latter builds GtkD from source and needs `ldc2` on `PATH`.

## Why uniform across all three images

C-wide rather than Testing-only. Two reasons:

- **Same compiler version everywhere.** Pinning to LDC 1.40.0 (what Trixie/Stable ships) means we are no longer silently testing different toolchains across suites.
- **One codepath.** Same shape as the GtkD-from-source pattern in #49, which is already wide.

A future apt-archive disruption on any suite will no longer break the CI.

The `Dub` matrix job (separate file, uses `dlang-community/setup-dlang`) is untouched — it does not go through these Dockerfiles.

## Test plan

- [x] Tarball URL resolves: `curl -sIL https://github.com/ldc-developers/ldc/releases/download/v1.40.0/ldc2-1.40.0-linux-x86_64.tar.xz` → `HTTP/2 200`, 86 MB
- [x] `sh -n` syntax check passes on `install-ldc-tarball.sh`
- [ ] CI: Debian Stable image rebuilds and tests pass
- [ ] CI: Debian Testing image rebuilds and tests pass (this is the unblock)
- [ ] CI: Ubuntu Noble image rebuilds and tests pass
- [ ] Manual: `ldc2 --version` inside the resulting container reports 1.40.0

## CHANGELOG

Entry added under `Unreleased` → `Fixed` mirroring the #49 phrasing.