### PR TITLE
fix: Show stackMaximized before setVisibleChild on session restore (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Debug log path resolution now prefers `$XDG_RUNTIME_DIR/ttyx.log` over `/tmp/ttyx.log` when file logging is enabled (#55).
 
 ### Fixed
+- **Maximized terminal not restored on session load** — loading a saved session whose JSON has `maximized: true` on a child no longer leaves the user looking at the half-empty Paned. Root cause: `gtk_stack_set_visible_child` is a silent no-op when the target child has never been shown, and on the restore path `parseSession` runs before `nb.showAll()` cascades show to the stack pages. Fixed by explicitly calling `show()` on the maximized stack page before switching to it; idempotent in the user-triggered Ctrl+Shift+X path. Pre-existing since the upstream Tilix 2017 implementation; surfaced in #91 during the #89 refactor smoke test (#91).
 - **Password manager delete silently failed** — the delete button claimed success even when the keyring operation failed, and legacy-schema entries from the Tilix migration couldn't be deleted at all (#50, #54).
 - **Proxy URL malformed** — the generated `http_proxy` URL had a redundant leading `@` before userinfo, which strict RFC-3986 parsers reject; credentials were also not percent-encoded, so passwords containing `@`, `:`, `/` broke the URL entirely (#51, #55).
 - **`https_proxy` missing authentication** — the auth block was gated on `scheme == "http"` so the HTTPS proxy never received credentials even when configured (#51, #55).

--- a/source/gx/ttyx/session.d
+++ b/source/gx/ttyx/session.d
@@ -735,6 +735,14 @@ private:
         stackMaximized.add(terminal);
         trace("Switching stack to maximized page");
         terminal.show();
+        // gtk_stack_set_visible_child is a silent no-op if the target child
+        // has never had gtk_widget_show called on it. On the session-restore
+        // path this method runs before nb.showAll() cascades show to our
+        // stack pages, so without this explicit show() the maximize state is
+        // lost — GtkStack later picks the first shown child (stackGroup) as
+        // visible-child, leaving the user looking at the half-empty Paned.
+        // Idempotent in the user-triggered Ctrl+Shift+X path. (#91)
+        stackMaximized.show();
         setVisibleChild(stackMaximized);
         notifySessionStateChange(SessionStateChange.TERMINAL_MAXIMIZED);
         return true;


### PR DESCRIPTION
## Summary

Fixes #91. When loading a saved session with a maximized terminal, the maximized state is silently lost and the user sees the half-empty Paned (other terminal at original size, big dark area where the maximized terminal *should* be).

Root cause: `gtk_stack_set_visible_child()` is a silent no-op when the target child has never had `gtk_widget_show` called. On the restore path, `parseSession` calls `maximizeTerminal` → `setVisibleChild(stackMaximized)` *before* `nb.showAll()` has cascaded show through the new tab's widget tree. The `addOnRealize` fallback that was supposed to catch this case fails too — at session realize, the stack pages still aren't shown.

One-line fix: `stackMaximized.show()` before `setVisibleChild`. Idempotent in the user-triggered Ctrl+Shift+X path where the stack page is already visible.

Pre-existing since the upstream Tilix 2017 maximize work, surfaced now during PR #89's smoke test.

## Verification

Instrumented `parseSession` / `maximizeTerminal` / `addOnRealize` / `addOnMap` / `notify::visible-child` and reproduced in two paths before and after the fix:

**Before fix, menu-load equivalent (delayed-load hook into a running app):**
```
maximizeTerminal: setVisibleChild(stackMaximized) called; visibleChild= ...stackMaxVisible=false...
onRealize fired; isMax=true visChild= sgVis=false smVis=false
onRealize after setVisible(stackMax); visChild=          ← silently dropped
notify::visible-child; visChild=group ...                ← GTK picks first shown child
onMap fired; isMax=true visChild=group                   ← BUG visible
```

**After fix, same path:**
```
notify::visible-child; visChild=maximized sgVis=false smVis=true   ← stick
maximizeTerminal: setVisibleChild called; visibleChild=maximized stackMaxVisible=true
onRealize fired; isMax=true visChild=maximized
onMap fired; isMax=true visChild=maximized                          ← FIXED
```

The `-s session.json` auto-load path was already (mostly) working — `nb.showAll()` ran early enough that the `addOnRealize` fallback caught it. Menu-load path was broken because by the time `addSession` runs `nb.showAll()`, the children of the new session's stack are still hidden during the early realize.

## Test plan

- [x] `meson test -C builddir --print-errorlogs` — 3/3 pass
- [x] Reproduce bug, instrument, fix, re-verify in delayed-load (menu-load equivalent)
- [x] Verify `-s session.json` path still works
- [ ] Manual smoke test: load /tmp/test.jspn.json via menu in a running ttyx — maximized terminal should now fill the tab
- [ ] Manual smoke test: Ctrl+Shift+X user-triggered maximize should still work (idempotent show())