### PR TITLE
feat: Support OSC 11 (dynamic background color) (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 ### Added
+- **OSC 11 (dynamic background color) support** — apps like neovim and theme-switching scripts can now change the terminal background at runtime via `printf '\033]11;#rrggbb\007'`; reset with `printf '\033]111\007'`. ttyx_ no longer disables VTE's native background painting, so OSC 11 is honoured natively. The badge draw signal moved from the BEFORE phase to AFTER so badges still render on top of the terminal output (#47).
 - Documentation site at <https://gwelr.github.io/ttyx_/> — built with Jekyll + just-the-docs, manual content adapted from upstream Tilix under MPL-2.0 (#59, #60, #61, #63, #64).
 - Unit test coverage for the password manager row-removal path, extracted as `removeRowById` (#54).
 - Unit tests for the proxy URL builder, sensitive-value redaction, and process introspection helpers (#55, #56, #58).

--- a/source/gx/ttyx/constants.d
+++ b/source/gx/ttyx/constants.d
@@ -38,12 +38,6 @@ immutable bool USE_FILE_LOGGING = false;
  */
 immutable bool USE_COMMIT_SYNCHRONIZATION = false;
 
-/**
- * Compile with support for VTE method vte_terminal_get_color_background_for_draw,
- * only needed until VTE 0.54 is released and GtkD is updated.
- */
-immutable bool COMPILE_VTE_BACKGROUND_COLOR = false;
-
 /**************************************
  * Application Constants
  **************************************/

--- a/source/gx/ttyx/terminal/exvte.d
+++ b/source/gx/ttyx/terminal/exvte.d
@@ -188,12 +188,6 @@ public:
 		vte_terminal_set_disable_bg_draw(vteTerminal, isDisabled);
     }
 
-static if (COMPILE_VTE_BACKGROUND_COLOR) {
-    public void getColorBackgroundForDraw(RGBA background) {
-		vte_terminal_get_color_background_for_draw(vteTerminal, background is null? null: background.getRGBAStruct());
-    }
-}
-
     /**
      * Returns the child pid running in the terminal or -1
      * if no child pid is running. May also return the VTE gpid
@@ -236,18 +230,10 @@ static if (__traits(compiles, { alias _ = vte.c.functions.vte_terminal_paste_tex
 __gshared extern(C) {
 	int function(VteTerminal* terminal) c_vte_terminal_get_disable_bg_draw;
 	void function(VteTerminal* terminal, int isAudible) c_vte_terminal_set_disable_bg_draw;
-
-	static if (COMPILE_VTE_BACKGROUND_COLOR) {
-		void function(VteTerminal* terminal, GdkRGBA* color) c_vte_terminal_get_color_background_for_draw;
-	}
 }
 
 alias vte_terminal_get_disable_bg_draw = c_vte_terminal_get_disable_bg_draw;
 alias vte_terminal_set_disable_bg_draw = c_vte_terminal_set_disable_bg_draw;
-
-static if (COMPILE_VTE_BACKGROUND_COLOR) {
-	alias vte_terminal_get_color_background_for_draw = c_vte_terminal_get_color_background_for_draw;
-}
 
 shared static this() {
 	Linker.link(vte_terminal_get_disable_bg_draw, "vte_terminal_get_disable_bg_draw", LIBRARY_VTE);
@@ -256,10 +242,6 @@ shared static this() {
 	// Only link our own binding if GtkD doesn't provide it
 	static if (!__traits(compiles, { alias _ = vte.c.functions.vte_terminal_paste_text; })) {
 		Linker.link(_vtePasteText, "vte_terminal_paste_text", LIBRARY_VTE);
-	}
-
-	static if (COMPILE_VTE_BACKGROUND_COLOR) {
-		Linker.link(vte_terminal_get_color_background_for_draw, "vte_terminal_get_color_background_for_draw", LIBRARY_VTE);
 	}
 }
 

--- a/source/gx/ttyx/terminal/renderer.d
+++ b/source/gx/ttyx/terminal/renderer.d
@@ -25,9 +25,7 @@ import gtk.Widget : Widget;
 import pango.c.types : PANGO_SCALE = SCALE;
 
 import gx.gtk.color : adjustColor, contrast;
-import gx.gtk.vte : isVTEBackgroundDrawEnabled, checkVTEVersion, VTE_VERSION_BACKGROUND_GET_COLOR,
-    VTE_VERSION_BACKGROUND_OPERATOR;
-import gx.ttyx.constants : COMPILE_VTE_BACKGROUND_COLOR;
+import gx.gtk.vte : isVTEBackgroundDrawEnabled;
 import gx.ttyx.preferences;
 import gx.ttyx.terminal.context;
 import gx.ttyx.terminal.types;
@@ -76,10 +74,6 @@ private:
     RGBA _vteBold;
     RGBA _dimBold;
     double _dimPercent;
-
-    static if (COMPILE_VTE_BACKGROUND_COLOR) {
-        RGBA _drawBG;
-    }
 
     enum STROKE_WIDTH = 4;
     enum BADGE_MARGIN = 10;
@@ -334,26 +328,8 @@ public:
         auto vte = _ctx.contextVte();
         auto gsProfile = _ctx.contextGsProfile();
 
-        // Paint background if VTE background draw is disabled
-        if (isVTEBackgroundDrawEnabled()) {
-            static if (COMPILE_VTE_BACKGROUND_COLOR) {
-                if (checkVTEVersion(VTE_VERSION_BACKGROUND_GET_COLOR)) {
-                    if (_drawBG is null) _drawBG = new RGBA();
-                    vte.getColorBackgroundForDraw(_drawBG);
-                } else {
-                    _drawBG = _vteBG;
-                }
-                cr.setSourceRgba(_drawBG.red, _drawBG.green, _drawBG.blue, _drawBG.alpha);
-            } else {
-                cr.setSourceRgba(_vteBG.red, _vteBG.green, _vteBG.blue, _vteBG.alpha);
-            }
-            import cairo.Types : cairo_operator_t;
-            cr.setOperator(cairo_operator_t.SOURCE);
-            cr.rectangle(0.0, 0.0, width, height);
-            cr.clip();
-            cr.paint();
-            cr.resetClip();
-        }
+        // Background painting is left to VTE so OSC 11 (dynamic background)
+        // works — see #47.
 
         // Draw margin line
         if (_margin > 0 && _marginEnabled) {

--- a/source/gx/ttyx/terminal/terminal.d
+++ b/source/gx/ttyx/terminal/terminal.d
@@ -1193,11 +1193,6 @@ private:
             });
         }
 
-        //Disable background draw if available
-        if (checkVTEFeature(TerminalFeature.DISABLE_BACKGROUND_DRAW) && !checkVTEVersion(VTE_VERSION_BACKGROUND_OPERATOR)) {
-            vte.setDisableBGDraw(true);
-        }
-
         Box box = new Box(Orientation.VERTICAL, 0);
         rFind = new SearchRevealer(vte, sagTerminalActions);
         rFind.onSearchEntryFocusIn.connect(&terminalWidgetFocusIn);
@@ -2665,12 +2660,20 @@ private:
         vte.addOnDragMotion(&onVTEDragMotion);
         vte.addOnDragLeave(&onVTEDragLeave);
 
-        if (checkVTEVersion(VTE_VERSION_BACKGROUND_OPERATOR)) {
-            vte.setClearBackground(false);
-        }
+        // Let VTE paint the terminal background natively. Required for
+        // OSC 11 (dynamic background-color) support — apps like neovim and
+        // theme-switching scripts rely on it. The pre-0.51 SOURCE-compositing
+        // workaround that disabled VTE's bg paint is no longer needed; VTE
+        // 0.51+ handles it correctly. (#47)
+        //
+        // Badge draws AFTER VTE's default handler so it appears on top of
+        // the terminal output. Pre-OSC-11 it ran BEFORE because we painted
+        // the background ourselves and let VTE's text overlay the badge;
+        // now VTE paints the bg in its default handler, which would erase
+        // anything we drew first.
         //TODO - Figure out why this is causing issues, see #545
         if (isVTEBackgroundDrawEnabled()) {
-            vte.addOnDraw(&renderer.onDrawBadge);
+            vte.addOnDraw(&renderer.onDrawBadge, ConnectFlags.AFTER);
         }
         vte.addOnDraw(&renderer.onDrawDragHighlight, ConnectFlags.AFTER);
 


### PR DESCRIPTION
Closes #47.

## Summary

ttyx_ ignored OSC 11 (`\e]11;#rrggbb\a`) because we disabled VTE's native background painting (a workaround for pre-0.51 SOURCE-compositing issues) and painted from the cached profile color in our own draw callback. Modern VTE handles background painting correctly; we just need to get out of the way.

Apps that use OSC 11: neovim, theme-switching scripts, shells syncing with the OS light/dark mode.

## Changes

- **`terminal.d`** — drop both `vte.setClearBackground(false)` (modern path) and `vte.setDisableBGDraw(true)` (the pre-0.51 tilix-patched path). Both told VTE "don't paint bg, we will" — we no longer want that.
- **`renderer.d`** — drop the manual bg-paint block in `onDrawBadge` and associated dead state (`_drawBG`, `COMPILE_VTE_BACKGROUND_COLOR`, version-constant imports).
- **`terminal.d`** — switch the badge `addOnDraw` from BEFORE → AFTER. Pre-fix order: ttyx paints bg + badge → VTE paints text. Post-fix order would have been: ttyx paints badge → VTE paints bg + text → badge erased. Badges now correctly draw on top of terminal output.
- **`exvte.d` / `constants.d`** — drop the `COMPILE_VTE_BACKGROUND_COLOR`-gated binding for `vte_terminal_get_color_background_for_draw`; only used by the now-removed manual paint path.

## Verification

Manual smoke test on the local build:

- [x] `printf '\e]11;#ff0000\a'` → bg turns red live
- [x] `printf '\e]11;#003366\a'` → bg turns dark blue
- [x] `printf '\e]111\a'` → reset to profile default
- [x] Badges still render correctly (Preferences → Badge tab, set text "TEST")
- [x] Profile bg color renders correctly when no OSC 11 active
- [x] Transparency slider still works
- [x] "Use theme colors" toggle still works
- [x] `meson test -C builddir --print-errorlogs` — 3/3 pass

## Reference

Mirrors @XertroV's tilix fork commit [`2a9a310e`](https://github.com/XertroV/tilix/commit/2a9a310eca61d6f01fe6e86818a8213dda0bd291), with the addition of switching the badge draw signal to AFTER (the fork didn't change the connect flag and likely had invisible badges as a regression).