### PR TITLE
release: 1.2.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.2.0-beta.1] — 2026-04-29
+
+First beta of the 1.2.0 release. Validation period before GA.
+
 ### Added
 - **OSC 11 (dynamic background color) support** — apps like neovim and theme-switching scripts can now change the terminal background at runtime via `printf '\033]11;#rrggbb\007'`; reset with `printf '\033]111\007'`. ttyx_ no longer disables VTE's native background painting, so OSC 11 is honoured natively. The badge draw signal moved from the BEFORE phase to AFTER so badges still render on top of the terminal output (#47).
 - Documentation site at <https://gwelr.github.io/ttyx_/> — built with Jekyll + just-the-docs, manual content adapted from upstream Tilix under MPL-2.0 (#59, #60, #61, #63, #64).

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,45 @@
+Version 1.2.0-beta.1
+~~~~~~~~~~~~~~~~~~~~
+Released: 2026-04-29
+
+Features:
+ * OSC 11 dynamic background color — apps like neovim and theme-switching
+   scripts can now change the terminal background at runtime via the OSC 11
+   escape sequence; reset with OSC 111
+ * enable-wide-handle defaults to true so the splitter between split
+   terminals is easier to see and grab on dark themes and HiDPI displays
+ * Auto-equalize panes on split and close, sway-style
+ * Documentation site at https://gwelr.github.io/ttyx_/
+ * Sensitive values redaction: passwords, tokens and proxy credentials are
+   stripped from trace logs, command-line argv and hyperlink click events
+   before reaching any log sink
+
+Bugfixes:
+ * Maximized terminal now correctly restores when loading a saved session;
+   fixes a long-standing bug pre-existing since the upstream Tilix 2017
+   implementation
+ * Trigger templates: $0 now correctly substitutes the whole match (was
+   shifted by one due to a size_t underflow); user templates relying on the
+   bugged behaviour need indices shifted up by one
+ * Triggers with an unrecognised action name are now skipped with a warning
+   instead of silently rewritten to UpdateState
+ * Paste hardening: strip OSC, DCS, APC and PM escape sequences from
+   clipboard content before paste
+ * Robust /proc/[pid]/stat parser with bounds validation
+ * Password manager delete now correctly reports keyring failures and
+   handles legacy Tilix-schema entries
+ * Proxy URL builder: percent-encode userinfo and drop the redundant leading
+   @; HTTPS proxy now receives credentials when configured
+
+Miscellaneous:
+ * First beta of the 1.2.0 release; validation period before GA
+ * Internal refactors using D SumType for compile-time exhaustiveness:
+   TerminalRegex (BuiltinRegex/CustomRegex), SyncInputEvent, and a typed
+   TerminalSnapshot struct as the single source of truth for session
+   serialisation
+ * CI: install LDC from the upstream tarball; build GtkD from source on
+   Debian Testing where the apt package was removed
+
 Version 1.1.1
 ~~~~~~~~~~~~~~
 Released: 2026-04-18

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
     'ttyx', 'd',
-    version: '1.1.2',
+    version: '1.2.0-beta.1',
     license: 'MPL-2.0',
     meson_version: '>= 0.56'
 )


### PR DESCRIPTION
## Summary

First beta of the 1.2.0 release. Validation period before GA.

- Bump `meson.build` version: `1.1.2` → `1.2.0-beta.1` (strict SemVer)
- Roll `CHANGELOG.md`: `[Unreleased]` → `[1.2.0-beta.1] — 2026-04-29`, fresh empty `[Unreleased]` skeleton above
- Add `1.2.0-beta.1` entry to `NEWS` — meson runs `appstreamcli news-to-metainfo --limit=6 NEWS appdata.xml.in` at build time, so the AppStream `<releases>` block is auto-generated from this file (not edited in `appdata.xml.in` directly)

Note: the auto-generated AppStream entry will carry `type="stable"` because plain-text NEWS doesn't support per-entry type override (YAML format does, but that's a bigger refactor). The canonical pre-release signal is the `-beta.1` SemVer tag in the version string itself.

## Post-merge release steps

1. Tag `v1.2.0-beta.1` on the merge commit, push tag.
2. Bump flatpak manifest tag `v1.1.1` → `v1.2.0-beta.1` in a follow-up commit.
3. Local Flatpak build + sign checksums.
4. GitHub release marked **pre-release**.

## Test plan
- [ ] Local `meson setup builddir && ninja -C builddir` succeeds
- [ ] Local `meson test -C builddir --print-errorlogs` green
- [ ] `appstreamcli news-to-metainfo --limit=6 NEWS data/metainfo/io.github.gwelr.ttyx.appdata.xml.in -` produces valid metainfo with the new entry
- [ ] CI pipelines green on the PR

Drafted with help from Claude.