### PR TITLE
flatpak: Bump source tag to v1.2.0-beta.1

### DIFF
--- a/flatpak/io.github.gwelr.ttyx.yaml
+++ b/flatpak/io.github.gwelr.ttyx.yaml
@@ -101,4 +101,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/gwelr/ttyx_.git
-        tag: v1.1.1
+        tag: v1.2.0-beta.1


### PR DESCRIPTION
## Summary

Follow-up to release PR #98. The `v1.2.0-beta.1` tag now exists at commit `2ffaf8d3` (the merge commit of #98), so the Flatpak manifest can point at it for the local build + signed-checksum flow.

One-line change: `flatpak/io.github.gwelr.ttyx.yaml` `tag: v1.1.1` → `tag: v1.2.0-beta.1`.

## Test plan
- [ ] CI green on the PR
- [ ] Post-merge: local `flatpak-builder --install --user --force-clean ...` succeeds against this manifest

Drafted with help from Claude.